### PR TITLE
feat(dashboard): add summary, monthly and balances endpoints

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,6 +34,4 @@ jobs:
       - name: Build project
         run: dotnet build ExpenseApi.sln --no-restore
 
-      # Run the integration tests (Testcontainers uses the Docker daemon available on the runner).
-      - name: Run tests
-        run: dotnet test ExpenseApi.sln --no-build --verbosity normal
+      # Integration tests run in a dedicated workflow (.github/workflows/integration-tests.yml).

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Build project
         run: dotnet build ExpenseApi.sln --no-restore
 
-      # Uncomment to run tests
-      # - name: Run tests
-      #   run: dotnet test --no-build --verbosity normal
+      # Run the integration tests (Testcontainers uses the Docker daemon available on the runner).
+      - name: Run tests
+        run: dotnet test ExpenseApi.sln --no-build --verbosity normal

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,47 @@
+# Runs the xUnit integration suite (Tests/Expense.API.IntegrationTests).
+# The tests spin up SQL Server + Redis via Testcontainers, which uses the Docker
+# daemon that is available by default on GitHub's ubuntu-latest runners.
+name: Integration Tests
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 7.0.x
+
+      - name: Restore
+        run: dotnet restore Tests/Expense.API.IntegrationTests/Expense.API.IntegrationTests.csproj
+
+      - name: Build
+        run: dotnet build Tests/Expense.API.IntegrationTests/Expense.API.IntegrationTests.csproj --no-restore --configuration Release
+
+      - name: Run integration tests
+        run: >
+          dotnet test Tests/Expense.API.IntegrationTests/Expense.API.IntegrationTests.csproj
+          --no-build --configuration Release --verbosity normal
+          --logger "trx;LogFileName=integration-tests.trx"
+          --results-directory ./TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-results
+          path: ./TestResults/*.trx
+          if-no-files-found: ignore

--- a/Controllers/ExpenseController.cs
+++ b/Controllers/ExpenseController.cs
@@ -294,6 +294,48 @@ namespace Expense.API.Controllers
             }
         }
 
+        // GET: api/Expense/summary?period=month
+        [HttpGet("summary")]
+        public async Task<IActionResult> GetSummary([FromQuery] string period = "month")
+        {
+            try
+            {
+                return Ok(await expenseRepository.GetDashboardSummaryAsync(period));
+            }
+            catch (Exception e)
+            {
+                return BadRequest($"An error occurred: {e.Message}");
+            }
+        }
+
+        // GET: api/Expense/monthly?months=6
+        [HttpGet("monthly")]
+        public async Task<IActionResult> GetMonthly([FromQuery] int months = 6)
+        {
+            try
+            {
+                return Ok(await expenseRepository.GetMonthlySpendingAsync(months));
+            }
+            catch (Exception e)
+            {
+                return BadRequest($"An error occurred: {e.Message}");
+            }
+        }
+
+        // GET: api/Expense/balances
+        [HttpGet("balances")]
+        public async Task<IActionResult> GetBalances()
+        {
+            try
+            {
+                return Ok(await expenseRepository.GetOutstandingBalancesAsync());
+            }
+            catch (Exception e)
+            {
+                return BadRequest($"An error occurred: {e.Message}");
+            }
+        }
+
         [Authorize]
         [HttpGet("{expenseId}/doc/{docId}")]
         public async Task<IActionResult> GetResults(string expenseId, string docId)

--- a/Expense.API.csproj
+++ b/Expense.API.csproj
@@ -86,4 +86,10 @@
     <Compile Remove="Models\Domain\Document\DocumentResult.cs" />
     <Compile Remove="Middlewares\RequestHandlerMiddleware.cs" />
   </ItemGroup>
+  <!-- The integration test project lives under Tests/ and must not be compiled into the web app. -->
+  <ItemGroup>
+    <Compile Remove="Tests\**\*.cs" />
+    <Content Remove="Tests\**" />
+    <None Remove="Tests\**" />
+  </ItemGroup>
 </Project>

--- a/ExpenseAnalyserDbScripts/01-create_db.sql
+++ b/ExpenseAnalyserDbScripts/01-create_db.sql
@@ -1,2 +1,2 @@
-CREATE DATABASE ExpenseAnalyser;
+CREATE DATABASE ExpenseAnalyserDb;
 GO

--- a/ExpenseAnalyserDbScripts/02-user.sql
+++ b/ExpenseAnalyserDbScripts/02-user.sql
@@ -1,4 +1,4 @@
-USE ExpenseAnalyser;
+USE ExpenseAnalyserDb;
 GO
 
 SET ANSI_NULLS ON

--- a/ExpenseAnalyserDbScripts/03-expenses.sql
+++ b/ExpenseAnalyserDbScripts/03-expenses.sql
@@ -1,4 +1,4 @@
-USE ExpenseAnalyser
+USE ExpenseAnalyserDb
 GO
 
 SET ANSI_NULLS ON

--- a/ExpenseAnalyserDbScripts/04-documents.sql
+++ b/ExpenseAnalyserDbScripts/04-documents.sql
@@ -1,4 +1,4 @@
-USE ExpenseAnalyser
+USE ExpenseAnalyserDb
 GO
 SET ANSI_NULLS ON
 GO

--- a/ExpenseAnalyserDbScripts/05-expense_users.sql
+++ b/ExpenseAnalyserDbScripts/05-expense_users.sql
@@ -1,4 +1,4 @@
-USE ExpenseAnalyser
+USE ExpenseAnalyserDb
 GO
 SET ANSI_NULLS ON
 GO
@@ -7,7 +7,9 @@ GO
 CREATE TABLE [dbo].[ExpenseUsers](
 	[ExpenseId] [uniqueidentifier] NOT NULL,
 	[UserId] [uniqueidentifier] NOT NULL,
- CONSTRAINT [PK_ExpenseUsers] PRIMARY KEY CLUSTERED 
+	[UserShare] [float] NOT NULL CONSTRAINT [DF_ExpenseUsers_UserShare] DEFAULT (0),
+	[UserAmount] [float] NULL,
+ CONSTRAINT [PK_ExpenseUsers] PRIMARY KEY CLUSTERED
 (
 	[ExpenseId] ASC,
 	[UserId] ASC

--- a/ExpenseAnalyserDbScripts/06-document_job_results.sql
+++ b/ExpenseAnalyserDbScripts/06-document_job_results.sql
@@ -1,4 +1,4 @@
-USE ExpenseAnalyser
+USE ExpenseAnalyserDb
 GO
 SET ANSI_NULLS ON
 GO

--- a/ExpenseAnalyserDbScripts/07-notification.sql
+++ b/ExpenseAnalyserDbScripts/07-notification.sql
@@ -1,4 +1,4 @@
-USE ExpenseAnalyser
+USE ExpenseAnalyserDb
 GO
 SET ANSI_NULLS ON
 GO

--- a/ExpenseAnalyserDbScripts/09-add-expense-category.sql
+++ b/ExpenseAnalyserDbScripts/09-add-expense-category.sql
@@ -1,0 +1,10 @@
+USE ExpenseAnalyserDb;
+GO
+
+-- Dashboard: spending category on Expense (nullable; null = "Other").
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE Name = N'Category'
+               AND Object_ID = Object_ID(N'dbo.Expenses'))
+BEGIN
+    ALTER TABLE dbo.Expenses ADD Category NVARCHAR(64) NULL;
+END
+GO

--- a/ExpenseAnalyserDbScripts/seed-data.sql
+++ b/ExpenseAnalyserDbScripts/seed-data.sql
@@ -1,0 +1,81 @@
+-- =============================================================================
+-- Realistic seed data for the ExpenseAnalyserDb business database.
+--
+-- Prerequisite: register the primary user through the API FIRST so the Identity
+-- account (and password) exist and login works, e.g. via requests.http:
+--     POST /api/Auth/Register  { "userName": "alice", ... "roles": ["Writer"] }
+-- That call also inserts alice into dbo.Users. This script then looks alice up by
+-- username, creates her counterparties (bob, carol) and seeds expenses / receipts /
+-- splits so the dashboard endpoints return meaningful, eyeball-able numbers.
+--
+-- Run order:  01..07,09 (schema)  ->  register alice via API  ->  this script.
+-- Idempotent: it clears existing transactional rows (Expenses/Documents/ExpenseUsers)
+-- and the bob/carol users, then reseeds. It does NOT delete registered Users.
+-- =============================================================================
+USE ExpenseAnalyserDb;
+GO
+SET NOCOUNT ON;
+
+DECLARE @aliceUser NVARCHAR(256) = N'alice';   -- must match the username you registered
+DECLARE @aliceId UNIQUEIDENTIFIER = (SELECT TOP 1 Id FROM dbo.Users WHERE Username = @aliceUser);
+
+IF @aliceId IS NULL
+BEGIN
+    RAISERROR('User "%s" not found in dbo.Users. Register that user via POST /api/Auth/Register (with a role) before running this seed.', 16, 1, @aliceUser);
+    RETURN;
+END
+
+-- Reset transactional data so the script is re-runnable (safe on a test database).
+DELETE FROM dbo.ExpenseUsers;
+DELETE FROM dbo.Documents;
+DELETE FROM dbo.Expenses;
+DELETE FROM dbo.Users WHERE Username IN (N'bob', N'carol');
+
+-- Counterparties (business rows only; they never log in).
+DECLARE @bobId   UNIQUEIDENTIFIER = NEWID();
+DECLARE @carolId UNIQUEIDENTIFIER = NEWID();
+INSERT INTO dbo.Users (Id, Username, Email, CreatedAt) VALUES
+    (@bobId,   N'bob',   N'bob@test.local',   SYSUTCDATETIME()),
+    (@carolId, N'carol', N'carol@test.local', SYSUTCDATETIME());
+
+DECLARE @now DATETIME2 = SYSUTCDATETIME();
+DECLARE @thisMonth DATETIME2 = DATEFROMPARTS(YEAR(@now), MONTH(@now), 15);
+
+-- ---- Alice's spending THIS month (drives summary?period=month) ---------------
+DECLARE @travel UNIQUEIDENTIFIER = NEWID();
+INSERT INTO dbo.Expenses (Id, Title, Description, Amount, CreatedAt, CreatedById, Category) VALUES
+    (@travel, N'Flight',    N'Flight to NYC',  300.00, @thisMonth, @aliceId, N'Travel'),
+    (NEWID(), N'Groceries', N'Weekly shop',    120.50, @thisMonth, @aliceId, N'Groceries'),
+    (NEWID(), N'Dinner',    N'Team dinner',      45.00, @thisMonth, @aliceId, N'Dining'),
+    (NEWID(), N'Misc',      N'Uncategorised',    30.00, @thisMonth, @aliceId, NULL);
+-- Expected summary TotalSpent (month) = 495.50; Categories: Travel 300, Groceries 120.50, Dining 45, Other 30.
+
+-- ---- Alice's spending in PRIOR months (drives monthly chart) -----------------
+INSERT INTO dbo.Expenses (Id, Title, Description, Amount, CreatedAt, CreatedById, Category) VALUES
+    (NEWID(), N'Groceries', N'Last month shop', 80.00, DATEADD(MONTH, -1, @thisMonth), @aliceId, N'Groceries'),
+    (NEWID(), N'Hotel',     N'2 months ago',   150.00, DATEADD(MONTH, -2, @thisMonth), @aliceId, N'Travel'),
+    (NEWID(), N'Dinner',    N'3 months ago',    60.00, DATEADD(MONTH, -3, @thisMonth), @aliceId, N'Dining');
+-- Expected monthly?months=6: current 495.50, -1 80, -2 150, -3 60, others 0.
+
+-- ---- Receipts uploaded by Alice this month (drives ReceiptsScanned) ----------
+INSERT INTO dbo.Documents (Id, FileName, FileExtension, S3Url, ETag, VersionId, Size, UploadedAt, UserId, ExpenseId) VALUES
+    (NEWID(), N'flight.pdf',  N'.pdf', N'https://example.com/flight.pdf',  N'etag1', N'v1', 2048, @thisMonth, @aliceId, @travel),
+    (NEWID(), N'grocery.jpg', N'.jpg', N'https://example.com/grocery.jpg', N'etag2', N'v1', 1024, @thisMonth, @aliceId, @travel);
+-- Expected ReceiptsScanned (month) = 2.
+
+-- ---- Splits: Bob & Carol owe Alice on her Travel expense (OwedToYou) ---------
+INSERT INTO dbo.ExpenseUsers (ExpenseId, UserId, UserShare, UserAmount) VALUES
+    (@travel, @bobId,   0.33, 100.00),
+    (@travel, @carolId, 0.33,  50.00);
+-- Expected OwedToYou = 150; balances.OwedToYou = [bob 100, carol 50].
+
+-- ---- A Bob-created expense on which Alice owes 45 (YouOwe) --------------------
+DECLARE @concert UNIQUEIDENTIFIER = NEWID();
+INSERT INTO dbo.Expenses (Id, Title, Description, Amount, CreatedAt, CreatedById, Category) VALUES
+    (@concert, N'Concert', N'Concert tickets', 90.00, @thisMonth, @bobId, N'Entertainment');
+INSERT INTO dbo.ExpenseUsers (ExpenseId, UserId, UserShare, UserAmount) VALUES
+    (@concert, @aliceId, 0.50, 45.00);
+-- Expected YouOwe = 45; balances.YouOwe = [bob 45].
+
+PRINT 'Seed complete for user alice (+ bob, carol).';
+GO

--- a/ExpenseApi.sln
+++ b/ExpenseApi.sln
@@ -1,22 +1,54 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Expense.API", "Expense.API.csproj", "{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Expense.API.IntegrationTests", "Tests\Expense.API.IntegrationTests\Expense.API.IntegrationTests.csproj", "{6D4937E6-60D8-4416-80A4-02DFB9850D61}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Debug|x64.Build.0 = Debug|Any CPU
+		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Debug|x86.Build.0 = Debug|Any CPU
 		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Release|x64.ActiveCfg = Release|Any CPU
+		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Release|x64.Build.0 = Release|Any CPU
+		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Release|x86.ActiveCfg = Release|Any CPU
+		{1F91D325-13DE-4BEF-8AD0-2DC9BE25B775}.Release|x86.Build.0 = Release|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Debug|x64.Build.0 = Debug|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Debug|x86.Build.0 = Debug|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Release|x64.ActiveCfg = Release|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Release|x64.Build.0 = Release|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Release|x86.ActiveCfg = Release|Any CPU
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{6D4937E6-60D8-4416-80A4-02DFB9850D61} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4EE783C7-6967-4900-8F2B-2DE7CA1EFC36}

--- a/Models/DTO/AddExpenseDto.cs
+++ b/Models/DTO/AddExpenseDto.cs
@@ -10,6 +10,7 @@ namespace Expense.API.Models.DTO
 		public string Title { get; set; }
         public string Description { get; set; }
         public decimal Amount { get; set; }
+        public string? Category { get; set; }
     }
 }
 

--- a/Models/DTO/DashboardSummaryDto.cs
+++ b/Models/DTO/DashboardSummaryDto.cs
@@ -1,0 +1,32 @@
+namespace Expense.API.Models.DTO
+{
+    /// <summary>
+    /// KPI strip + category donut for the dashboard homescreen, scoped to the current user and period.
+    /// </summary>
+    public class DashboardSummaryDto
+    {
+        /// <summary>SUM(Amount) of expenses I created in the period.</summary>
+        public decimal TotalSpent { get; set; }
+
+        /// <summary>COUNT of documents I uploaded in the period.</summary>
+        public int ReceiptsScanned { get; set; }
+
+        /// <summary>SUM(UserAmount) of my shares on expenses created by others.</summary>
+        public double YouOwe { get; set; }
+
+        /// <summary>SUM(UserAmount) owed to me by others on expenses I created.</summary>
+        public double OwedToYou { get; set; }
+
+        /// <summary>TotalSpent change vs the previous comparable period, as a percentage.</summary>
+        public double TotalSpentDeltaPct { get; set; }
+
+        /// <summary>Spending grouped by category (null buckets into "Other").</summary>
+        public List<CategoryBreakdownDto> Categories { get; set; } = new();
+    }
+
+    public class CategoryBreakdownDto
+    {
+        public string Category { get; set; }
+        public decimal Amount { get; set; }
+    }
+}

--- a/Models/DTO/MonthlySpendingDto.cs
+++ b/Models/DTO/MonthlySpendingDto.cs
@@ -1,0 +1,16 @@
+namespace Expense.API.Models.DTO
+{
+    /// <summary>
+    /// One bar in the dashboard's monthly-spending chart: SUM(Amount) for a single month.
+    /// </summary>
+    public class MonthlySpendingDto
+    {
+        public int Year { get; set; }
+        public int Month { get; set; }
+
+        /// <summary>Short month label for the chart axis, e.g. "Jun".</summary>
+        public string Label { get; set; }
+
+        public decimal Amount { get; set; }
+    }
+}

--- a/Models/DTO/OutstandingBalancesDto.cs
+++ b/Models/DTO/OutstandingBalancesDto.cs
@@ -1,0 +1,21 @@
+namespace Expense.API.Models.DTO
+{
+    /// <summary>
+    /// Outstanding balances panel: gross amounts owed per counterparty, split by direction.
+    /// </summary>
+    public class OutstandingBalancesDto
+    {
+        /// <summary>People I owe (my shares on expenses they created).</summary>
+        public List<BalanceEntryDto> YouOwe { get; set; } = new();
+
+        /// <summary>People who owe me (their shares on expenses I created).</summary>
+        public List<BalanceEntryDto> OwedToYou { get; set; } = new();
+    }
+
+    public class BalanceEntryDto
+    {
+        public Guid UserId { get; set; }
+        public string UserName { get; set; }
+        public double Amount { get; set; }
+    }
+}

--- a/Models/DTO/UpdateExpenseDto.cs
+++ b/Models/DTO/UpdateExpenseDto.cs
@@ -3,15 +3,17 @@ namespace Expense.API.Models.DTO
 {
 	public class UpdateExpenseDto
 	{
-		public UpdateExpenseDto(string id, string title, string description)
+		public UpdateExpenseDto(string id, string title, string description, string? category = null)
 		{
 			this.Id = id;
 			this.Description = description;
 			this.Title = title;
+			this.Category = category;
 		}
         public string Id { get; set; }
         public string Title { get; set; }
         public string Description { get; set; }
+        public string? Category { get; set; }
     }
 }
 

--- a/Models/Domain/Expense/Expense.cs
+++ b/Models/Domain/Expense/Expense.cs
@@ -16,6 +16,11 @@
         public Guid CreatedById { get; set; }  // Foreign key for User
         public User CreatedBy { get; set; }     // Navigation property
 
+        /// <summary>
+        /// Spending category for dashboard breakdowns (e.g. Groceries, Dining). Null = uncategorised.
+        /// </summary>
+        public string? Category { get; set; }
+
         //Navgational Properties
 
         /// <summary>

--- a/Program.cs
+++ b/Program.cs
@@ -101,3 +101,6 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
 app.Run();
+
+// Exposed so the integration test project (WebApplicationFactory) can reference the entry point.
+public partial class Program { }

--- a/Repositories/Expense/ExpenseRepository.cs
+++ b/Repositories/Expense/ExpenseRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Claims;
+﻿using System.Globalization;
+using System.Security.Claims;
 using Microsoft.EntityFrameworkCore;
 using Expense.API.Data;
 using Expense.API.Models.Domain;
@@ -309,10 +310,174 @@ namespace Expense.API.Repositories.Expense
 
                 expense.Title = updateExpenseDto.Title;
                 expense.Description = updateExpenseDto.Description;
+                expense.Category = updateExpenseDto.Category;
                 await userDocumentsDbContext.SaveChangesAsync();
                 return expense;
             }
             throw new Exception("Update Failed, Expense Not found");
+        }
+
+        // ----- Dashboard -----
+
+        /// <summary>
+        /// Resolve the current user from the JWT NameIdentifier claim (same lookup as GetExpensesAsync).
+        /// </summary>
+        private async Task<User> GetCurrentUserAsync()
+        {
+            var userName = httpContextAccessor.HttpContext?.User?.Claims
+                             .FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
+
+            var user = await userDocumentsDbContext.Users
+                            .FirstOrDefaultAsync(u => u.Username.Equals(userName));
+
+            if (user == null)
+            {
+                throw new Exception("Invalid User");
+            }
+            return user;
+        }
+
+        /// <summary>
+        /// Map a period keyword to a [from, to] window. "quarter" = trailing 3 months,
+        /// "year" = current calendar year, anything else = current calendar month.
+        /// </summary>
+        private static (DateTime from, DateTime to) ResolveWindow(string period, DateTime now)
+        {
+            switch ((period ?? "month").Trim().ToLowerInvariant())
+            {
+                case "year":
+                    return (new DateTime(now.Year, 1, 1), now);
+                case "quarter":
+                    return (now.AddMonths(-3), now);
+                default: // "month"
+                    return (new DateTime(now.Year, now.Month, 1), now);
+            }
+        }
+
+        public async Task<DashboardSummaryDto> GetDashboardSummaryAsync(string period)
+        {
+            var user = await GetCurrentUserAsync();
+            var now = DateTime.UtcNow;
+            var (from, to) = ResolveWindow(period, now);
+            var prevFrom = from - (to - from); // previous comparable window
+
+            var myExpensesInWindow = userDocumentsDbContext.Expenses
+                .Where(e => e.CreatedById == user.Id && e.CreatedAt >= from && e.CreatedAt <= to);
+
+            var totalSpent = await myExpensesInWindow.SumAsync(e => (decimal?)e.Amount) ?? 0m;
+
+            var prevTotal = await userDocumentsDbContext.Expenses
+                .Where(e => e.CreatedById == user.Id && e.CreatedAt >= prevFrom && e.CreatedAt < from)
+                .SumAsync(e => (decimal?)e.Amount) ?? 0m;
+
+            var deltaPct = prevTotal == 0m
+                ? (totalSpent > 0m ? 100.0 : 0.0)
+                : (double)((totalSpent - prevTotal) / prevTotal) * 100.0;
+
+            var receiptsScanned = await userDocumentsDbContext.Documents
+                .CountAsync(d => d.UserId == user.Id && d.UploadedAt >= from && d.UploadedAt <= to);
+
+            var youOwe = await userDocumentsDbContext.ExpenseUsers
+                .Where(eu => eu.UserId == user.Id && eu.Expense.CreatedById != user.Id)
+                .SumAsync(eu => eu.UserAmount) ?? 0.0;
+
+            var owedToYou = await userDocumentsDbContext.ExpenseUsers
+                .Where(eu => eu.Expense.CreatedById == user.Id && eu.UserId != user.Id)
+                .SumAsync(eu => eu.UserAmount) ?? 0.0;
+
+            var categoriesRaw = await myExpensesInWindow
+                .GroupBy(e => e.Category)
+                .Select(g => new { g.Key, Amount = g.Sum(e => e.Amount) })
+                .ToListAsync();
+
+            var categories = categoriesRaw
+                .Select(c => new CategoryBreakdownDto { Category = c.Key ?? "Other", Amount = c.Amount })
+                .OrderByDescending(c => c.Amount)
+                .ToList();
+
+            return new DashboardSummaryDto
+            {
+                TotalSpent = totalSpent,
+                ReceiptsScanned = receiptsScanned,
+                YouOwe = youOwe,
+                OwedToYou = owedToYou,
+                TotalSpentDeltaPct = Math.Round(deltaPct, 1),
+                Categories = categories
+            };
+        }
+
+        public async Task<List<MonthlySpendingDto>> GetMonthlySpendingAsync(int months)
+        {
+            var user = await GetCurrentUserAsync();
+            if (months <= 0) months = 6;
+
+            var now = DateTime.UtcNow;
+            var startMonth = new DateTime(now.Year, now.Month, 1).AddMonths(-(months - 1));
+
+            var grouped = await userDocumentsDbContext.Expenses
+                .Where(e => e.CreatedById == user.Id && e.CreatedAt >= startMonth)
+                .GroupBy(e => new { e.CreatedAt.Year, e.CreatedAt.Month })
+                .Select(g => new { g.Key.Year, g.Key.Month, Amount = g.Sum(e => e.Amount) })
+                .ToListAsync();
+
+            var result = new List<MonthlySpendingDto>();
+            for (int i = 0; i < months; i++)
+            {
+                var m = startMonth.AddMonths(i);
+                var match = grouped.FirstOrDefault(x => x.Year == m.Year && x.Month == m.Month);
+                result.Add(new MonthlySpendingDto
+                {
+                    Year = m.Year,
+                    Month = m.Month,
+                    Label = m.ToString("MMM", CultureInfo.InvariantCulture),
+                    Amount = match?.Amount ?? 0m
+                });
+            }
+            return result;
+        }
+
+        public async Task<OutstandingBalancesDto> GetOutstandingBalancesAsync()
+        {
+            var user = await GetCurrentUserAsync();
+
+            // People I owe: my shares on expenses created by others, grouped by the creator.
+            var youOweRaw = await userDocumentsDbContext.ExpenseUsers
+                .Where(eu => eu.UserId == user.Id && eu.Expense.CreatedById != user.Id)
+                .GroupBy(eu => eu.Expense.CreatedById)
+                .Select(g => new { CounterpartyId = g.Key, Amount = g.Sum(eu => eu.UserAmount) })
+                .ToListAsync();
+
+            // People who owe me: others' shares on expenses I created, grouped by the sharer.
+            var owedToYouRaw = await userDocumentsDbContext.ExpenseUsers
+                .Where(eu => eu.Expense.CreatedById == user.Id && eu.UserId != user.Id)
+                .GroupBy(eu => eu.UserId)
+                .Select(g => new { CounterpartyId = g.Key, Amount = g.Sum(eu => eu.UserAmount) })
+                .ToListAsync();
+
+            var ids = youOweRaw.Select(x => x.CounterpartyId)
+                .Concat(owedToYouRaw.Select(x => x.CounterpartyId))
+                .Distinct()
+                .ToList();
+
+            var names = await userDocumentsDbContext.Users
+                .Where(u => ids.Contains(u.Id))
+                .ToDictionaryAsync(u => u.Id, u => u.Username);
+
+            List<BalanceEntryDto> Project(IEnumerable<dynamic> rows) => rows
+                .Select(r => new BalanceEntryDto
+                {
+                    UserId = r.CounterpartyId,
+                    UserName = names.TryGetValue((Guid)r.CounterpartyId, out string n) ? n : "Unknown",
+                    Amount = (double)(r.Amount ?? 0.0)
+                })
+                .OrderByDescending(b => b.Amount)
+                .ToList();
+
+            return new OutstandingBalancesDto
+            {
+                YouOwe = Project(youOweRaw),
+                OwedToYou = Project(owedToYouRaw)
+            };
         }
     }
 }

--- a/Repositories/Expense/IExpenseRepository.cs
+++ b/Repositories/Expense/IExpenseRepository.cs
@@ -88,6 +88,22 @@ namespace Expense.API.Repositories.Expense
         /// <returns></returns>
         public Task<List<ExpenseUser>> GetAssignUsers(Guid expenseId);
 
+        /// <summary>
+        /// Dashboard KPI strip + category breakdown for the current user, scoped to a period
+        /// ("month" | "quarter" | "year").
+        /// </summary>
+        public Task<DashboardSummaryDto> GetDashboardSummaryAsync(string period);
+
+        /// <summary>
+        /// Dashboard bar chart: SUM(Amount) per month for the current user over the last N months
+        /// (gap months filled with 0).
+        /// </summary>
+        public Task<List<MonthlySpendingDto>> GetMonthlySpendingAsync(int months);
+
+        /// <summary>
+        /// Dashboard outstanding balances: gross amounts owed per counterparty, split by direction.
+        /// </summary>
+        public Task<OutstandingBalancesDto> GetOutstandingBalancesAsync();
 
     }
 }

--- a/Tests/Expense.API.IntegrationTests/AuthTests.cs
+++ b/Tests/Expense.API.IntegrationTests/AuthTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Http.Json;
+using Expense.API.IntegrationTests.Infrastructure;
+using Expense.API.Models.DTO;
+using FluentAssertions;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+public class AuthTests : IntegrationTestBase
+{
+    public AuthTests(CustomWebAppFactory factory) : base(factory) { }
+
+    [Fact]
+    public async Task Register_with_role_then_login_sets_jwt_cookie()
+    {
+        var user = await RegisterAndLoginAsync("alice");
+
+        // The login handler appends the jwtToken cookie; the client kept it, so a protected
+        // endpoint now succeeds.
+        var summary = await user.Client.GetAsync("/api/Expense/summary?period=month");
+        summary.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Register_without_role_is_rejected()
+    {
+        var client = Factory.CreateClient();
+        var userName = Unique("norole");
+
+        var res = await client.PostAsJsonAsync("/api/Auth/Register", new RegisterRequestDto
+        {
+            Email = $"{userName}@test.local",
+            UserName = userName,
+            Password = "Passw0rd!",
+            Roles = Array.Empty<string>()
+        });
+
+        // Without a role the business Users row is never created -> BadRequest.
+        res.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Register_duplicate_email_is_rejected()
+    {
+        var user = await RegisterAndLoginAsync("dup");
+        var client = Factory.CreateClient();
+
+        var res = await client.PostAsJsonAsync("/api/Auth/Register", new RegisterRequestDto
+        {
+            Email = user.Email,
+            UserName = Unique("dup2"),
+            Password = "Passw0rd!",
+            Roles = new[] { "Writer" }
+        });
+
+        res.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Login_with_wrong_password_fails()
+    {
+        var user = await RegisterAndLoginAsync("wrongpw");
+        var client = Factory.CreateClient();
+
+        var res = await client.PostAsJsonAsync("/api/Auth/Login", new LoginRequestDto
+        {
+            Username = user.UserName,
+            Password = "Nope123!"
+        });
+
+        res.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await res.Content.ReadFromJsonAsync<LoginResponseDto>();
+        body!.IsLoggedIn.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CheckSession_reflects_authentication_state()
+    {
+        var anon = Factory.CreateClient();
+        var anonSession = await anon.GetFromJsonAsync<SessionDataDto>("/api/Auth/checkSession");
+        anonSession!.IsLoggedIn.Should().BeFalse();
+
+        var user = await RegisterAndLoginAsync("sess");
+        var authed = await user.Client.GetFromJsonAsync<SessionDataDto>("/api/Auth/checkSession");
+        authed!.IsLoggedIn.Should().BeTrue();
+        authed.UserName.Should().Be(user.UserName);
+    }
+
+    [Fact]
+    public async Task Protected_endpoint_requires_authentication()
+    {
+        var anon = Factory.CreateClient();
+        var res = await anon.GetAsync("/api/Expense/balances");
+        res.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/AwsEndpointTests.cs
+++ b/Tests/Expense.API.IntegrationTests/AwsEndpointTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Expense.API.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+/// <summary>
+/// AWS-backed endpoints, driven against the mocked IAmazonS3 / IAmazonTextract registered by the
+/// factory. Covers the one cleanly-mockable happy path (S3 list-buckets) plus the authorization
+/// gates on every AWS endpoint, and the missing guard on Document DELETE.
+/// </summary>
+public class AwsEndpointTests : IntegrationTestBase
+{
+    public AwsEndpointTests(CustomWebAppFactory factory) : base(factory) { }
+
+    // NOTE: the S3 controller's route resolves to "api/S/list-buckets" (the [controller] token yields
+    // "S", not "S3") — a real routing quirk worth being aware of when the frontend calls it.
+    private const string ListBucketsUrl = "/api/S/list-buckets";
+
+    [Fact]
+    public async Task S3_list_buckets_returns_mocked_buckets_when_authenticated()
+    {
+        var user = await RegisterAndLoginAsync("s3");
+
+        var res = await user.Client.GetAsync(ListBucketsUrl);
+
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var buckets = await res.Content.ReadFromJsonAsync<List<JsonElement>>();
+        buckets!.Should().ContainSingle();
+        buckets[0].GetProperty("bucketName").GetString().Should().Be("expense-receipts-test-bucket");
+    }
+
+    [Theory]
+    [InlineData(ListBucketsUrl)]
+    [InlineData("/api/Document/downloadLinks")]
+    [InlineData("/api/Document/download/receipt.pdf")]
+    public async Task Aws_get_endpoints_require_authentication(string url)
+    {
+        var res = await Factory.CreateClient().GetAsync(url);
+        res.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Textract_start_requires_authentication()
+    {
+        var res = await Factory.CreateClient()
+            .PostAsync($"/api/Textract/startTextract?expenseGuid={Guid.NewGuid()}", null);
+        res.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Document_upload_requires_authentication()
+    {
+        using var content = new MultipartFormDataContent
+        {
+            { new StringContent(Guid.NewGuid().ToString()), "ExpenseId" }
+        };
+        var res = await Factory.CreateClient().PostAsync("/api/Document/upload", content);
+        res.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Document_delete_is_not_authorization_guarded()
+    {
+        // SECURITY GAP: DELETE /api/Document/{id} has no [Authorize]. An anonymous caller is therefore
+        // not rejected with 401; instead the repository throws "User not logged in", which the
+        // (catch-less) controller surfaces as a 500 via the exception middleware.
+        var res = await Factory.CreateClient().DeleteAsync($"/api/Document/{Guid.NewGuid()}");
+        res.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/CustomWebAppFactory.cs
+++ b/Tests/Expense.API.IntegrationTests/CustomWebAppFactory.cs
@@ -1,0 +1,105 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.Textract;
+using Expense.API.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Testcontainers.MsSql;
+using Testcontainers.Redis;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+/// <summary>
+/// Boots the real API pipeline (Program.cs) against throwaway SQL Server + Redis containers,
+/// with the AWS S3/Textract clients replaced by mocks so AWS-backed endpoints can be exercised
+/// without real credentials. One SQL container hosts both databases (AuthenticationDb +
+/// ExpenseAnalyserDb); the business schema is generated from the EF model (EnsureCreated) and the
+/// Identity schema from the existing migration (Migrate), sidestepping the raw DDL scripts.
+/// </summary>
+public class CustomWebAppFactory : WebApplicationFactory<Program>, IAsyncLifetime
+{
+    private readonly MsSqlContainer _sql = new MsSqlBuilder().Build();
+    private readonly RedisContainer _redis = new RedisBuilder().Build();
+
+    /// <summary>Mock S3 client shared by the host; tests can add setups on it.</summary>
+    public Mock<IAmazonS3> S3Mock { get; } = new(MockBehavior.Loose);
+
+    /// <summary>Mock Textract client shared by the host; tests can add setups on it.</summary>
+    public Mock<IAmazonTextract> TextractMock { get; } = new(MockBehavior.Loose);
+
+    public async Task InitializeAsync()
+    {
+        await Task.WhenAll(_sql.StartAsync(), _redis.StartAsync());
+
+        var baseConn = _sql.GetConnectionString(); // Database=master
+        var expenseConn = baseConn.Replace("Database=master", "Database=ExpenseAnalyserDb");
+        var authConn = baseConn.Replace("Database=master", "Database=AuthenticationDb");
+
+        // These are read by Program.cs *before* Build() (Redis connects eagerly), so they must be
+        // process environment variables rather than ConfigureAppConfiguration entries.
+        Environment.SetEnvironmentVariable("ConnectionStrings__ExpenseConnectionString", expenseConn);
+        Environment.SetEnvironmentVariable("ConnectionStrings__ExpenseAuthConnectionString", authConn);
+        Environment.SetEnvironmentVariable("ConnectionStrings__Redis", _redis.GetConnectionString());
+        // Issuer == Audience on purpose: JwtConfig validates the audience against Jwt:Issuer.
+        Environment.SetEnvironmentVariable("Jwt__Key", "integration-test-signing-key-at-least-32-chars-long");
+        Environment.SetEnvironmentVariable("Jwt__Issuer", "ExpenseApiTests");
+        Environment.SetEnvironmentVariable("Jwt__Audience", "ExpenseApiTests");
+        Environment.SetEnvironmentVariable("AWS__Region", "us-east-1");
+        Environment.SetEnvironmentVariable("AWS__BucketName", "expense-receipts-test-bucket");
+
+        // A sensible default so S3Controller/list-buckets returns a payload without per-test setup.
+        S3Mock.Setup(s => s.ListBucketsAsync(It.IsAny<CancellationToken>()))
+              .ReturnsAsync(new ListBucketsResponse
+              {
+                  Buckets = new List<S3Bucket> { new() { BucketName = "expense-receipts-test-bucket" } }
+              });
+
+        // Force host build, then provision both database schemas.
+        using var scope = Services.CreateScope();
+        var auth = scope.ServiceProvider.GetRequiredService<ExpenseAuthDbContext>();
+        await auth.Database.MigrateAsync();
+        var business = scope.ServiceProvider.GetRequiredService<UserDocumentsDbContext>();
+        await business.Database.EnsureCreatedAsync();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureTestServices(services =>
+        {
+            // Don't let the background Textract poller hammer the mocked AWS client on a loop.
+            var poller = services.SingleOrDefault(d =>
+                d.ImplementationType == typeof(Expense.API.Repositories.Background.TextractPollingRepository));
+            if (poller is not null) services.Remove(poller);
+
+            // Swap the real AWS clients for mocks.
+            services.RemoveAll<IAmazonS3>();
+            services.AddSingleton(S3Mock.Object);
+            services.RemoveAll<IAmazonTextract>();
+            services.AddSingleton(TextractMock.Object);
+
+            // Re-register the business context so EnsureCreated can materialise the schema despite the
+            // model's overlapping cascade-delete paths (see RestrictCascadeModelCustomizer).
+            var options = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<UserDocumentsDbContext>));
+            if (options is not null) services.Remove(options);
+            services.AddDbContext<UserDocumentsDbContext>(o => o
+                .UseSqlServer(Environment.GetEnvironmentVariable("ConnectionStrings__ExpenseConnectionString"))
+                .ReplaceService<Microsoft.EntityFrameworkCore.Infrastructure.IModelCustomizer,
+                    Infrastructure.RestrictCascadeModelCustomizer>());
+        });
+    }
+
+    public new async Task DisposeAsync()
+    {
+        await _sql.DisposeAsync();
+        await _redis.DisposeAsync();
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/DashboardTests.cs
+++ b/Tests/Expense.API.IntegrationTests/DashboardTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Net.Http.Json;
+using Expense.API.IntegrationTests.Infrastructure;
+using Expense.API.Models.DTO;
+using FluentAssertions;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+/// <summary>
+/// Exercises the dashboard endpoints against a hand-built, deterministic scenario and asserts the
+/// exact aggregated numbers. Mirrors the math in ExpenseRepository.GetDashboardSummaryAsync /
+/// GetMonthlySpendingAsync / GetOutstandingBalancesAsync.
+/// </summary>
+public class DashboardTests : IntegrationTestBase
+{
+    public DashboardTests(CustomWebAppFactory factory) : base(factory) { }
+
+    [Fact]
+    public async Task Summary_reports_totals_categories_and_owe_amounts()
+    {
+        var alice = await RegisterAndLoginAsync("alice");
+        var bob = await CreateBusinessUserAsync("bob");
+        var carol = await CreateBusinessUserAsync("carol");
+        var now = DateTime.UtcNow;
+
+        await WithDbAsync(async db =>
+        {
+            // Alice's own spending this month: 100 + 50 + 200 + 30 (uncategorised) = 380.
+            var travel = SeedData.AddExpense(db, alice.Id, "Flight", 200m, "Travel", now);
+            SeedData.AddExpense(db, alice.Id, "Groceries", 100m, "Groceries", now);
+            SeedData.AddExpense(db, alice.Id, "Dinner", 50m, "Dining", now);
+            SeedData.AddExpense(db, alice.Id, "Misc", 30m, null, now);
+
+            // Two receipts uploaded by Alice this month.
+            SeedData.AddReceipt(db, alice.Id, travel.Id, now);
+            SeedData.AddReceipt(db, alice.Id, travel.Id, now);
+
+            // Bob & Carol owe Alice on her expense: 25 + 15 = 40 (OwedToYou).
+            SeedData.AddShare(db, travel.Id, bob.Id, 25);
+            SeedData.AddShare(db, travel.Id, carol.Id, 15);
+
+            // Alice owes Bob 40 on an expense Bob created (YouOwe).
+            var bobExpense = SeedData.AddExpense(db, bob.Id, "Concert", 80m, "Entertainment", now);
+            SeedData.AddShare(db, bobExpense.Id, alice.Id, 40);
+
+            await db.SaveChangesAsync();
+        });
+
+        var summary = await alice.Client.GetFromJsonAsync<DashboardSummaryDto>("/api/Expense/summary?period=month");
+
+        summary!.TotalSpent.Should().Be(380m);
+        summary.ReceiptsScanned.Should().Be(2);
+        summary.YouOwe.Should().Be(40.0);
+        summary.OwedToYou.Should().Be(40.0);
+        summary.TotalSpentDeltaPct.Should().Be(100.0); // no prior-period spend
+        summary.Categories.Should().HaveCount(4);
+        summary.Categories[0].Category.Should().Be("Travel"); // highest amount first
+        summary.Categories[0].Amount.Should().Be(200m);
+        summary.Categories.Should().Contain(c => c.Category == "Other" && c.Amount == 30m);
+    }
+
+    [Fact]
+    public async Task Balances_group_amounts_by_counterparty_in_both_directions()
+    {
+        var alice = await RegisterAndLoginAsync("baluser");
+        var bob = await CreateBusinessUserAsync("balbob");
+        var carol = await CreateBusinessUserAsync("balcarol");
+        var now = DateTime.UtcNow;
+
+        await WithDbAsync(async db =>
+        {
+            var aliceExpense = SeedData.AddExpense(db, alice.Id, "Hotel", 300m, "Travel", now);
+            SeedData.AddShare(db, aliceExpense.Id, bob.Id, 120);
+            SeedData.AddShare(db, aliceExpense.Id, carol.Id, 80);
+
+            var bobExpense = SeedData.AddExpense(db, bob.Id, "Rental", 90m, "Travel", now);
+            SeedData.AddShare(db, bobExpense.Id, alice.Id, 45);
+
+            await db.SaveChangesAsync();
+        });
+
+        var balances = await alice.Client.GetFromJsonAsync<OutstandingBalancesDto>("/api/Expense/balances");
+
+        balances!.OwedToYou.Should().HaveCount(2);
+        balances.OwedToYou[0].UserName.Should().Be(bob.Username); // 120 sorted before 80
+        balances.OwedToYou[0].Amount.Should().Be(120.0);
+        balances.OwedToYou.Should().Contain(b => b.UserName == carol.Username && b.Amount == 80.0);
+
+        balances.YouOwe.Should().ContainSingle();
+        balances.YouOwe[0].UserName.Should().Be(bob.Username);
+        balances.YouOwe[0].Amount.Should().Be(45.0);
+    }
+
+    [Fact]
+    public async Task Monthly_returns_zero_filled_series_with_correct_amounts()
+    {
+        var dave = await RegisterAndLoginAsync("dave");
+        var now = DateTime.UtcNow;
+        var firstOfMonth = new DateTime(now.Year, now.Month, 1);
+        DateTime MonthAnchor(int monthsAgo) => firstOfMonth.AddMonths(-monthsAgo).AddDays(14);
+
+        await WithDbAsync(async db =>
+        {
+            SeedData.AddExpense(db, dave.Id, "This month", 100m, "Groceries", MonthAnchor(0));
+            SeedData.AddExpense(db, dave.Id, "Last month", 60m, "Dining", MonthAnchor(1));
+            SeedData.AddExpense(db, dave.Id, "Three months ago", 40m, "Travel", MonthAnchor(3));
+            await db.SaveChangesAsync();
+        });
+
+        var series = await dave.Client.GetFromJsonAsync<List<MonthlySpendingDto>>("/api/Expense/monthly?months=6");
+
+        series!.Should().HaveCount(6); // oldest first, current month last
+        series[5].Amount.Should().Be(100m);
+        series[4].Amount.Should().Be(60m);
+        series[2].Amount.Should().Be(40m);
+        series[0].Amount.Should().Be(0m);
+        series[5].Label.Should().Be(now.ToString("MMM", System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task Summary_with_no_data_returns_zeroes()
+    {
+        var lonely = await RegisterAndLoginAsync("lonely");
+
+        var summary = await lonely.Client.GetFromJsonAsync<DashboardSummaryDto>("/api/Expense/summary?period=month");
+
+        summary!.TotalSpent.Should().Be(0m);
+        summary.ReceiptsScanned.Should().Be(0);
+        summary.YouOwe.Should().Be(0.0);
+        summary.OwedToYou.Should().Be(0.0);
+        summary.Categories.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Summary_requires_authentication()
+    {
+        var res = await Factory.CreateClient().GetAsync("/api/Expense/summary");
+        res.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/Expense.API.IntegrationTests.csproj
+++ b/Tests/Expense.API.IntegrationTests/Expense.API.IntegrationTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.11" />
+    <PackageReference Include="Testcontainers.MsSql" Version="3.10.0" />
+    <PackageReference Include="Testcontainers.Redis" Version="3.10.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Expense.API.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Expense.API.IntegrationTests/ExpenseCrudTests.cs
+++ b/Tests/Expense.API.IntegrationTests/ExpenseCrudTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Expense.API.IntegrationTests.Infrastructure;
+using Expense.API.Models.DTO;
+using FluentAssertions;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+public class ExpenseCrudTests : IntegrationTestBase
+{
+    public ExpenseCrudTests(CustomWebAppFactory factory) : base(factory) { }
+
+    private sealed record ExpenseList(List<ExpenseDto> Expenses, int TotalRows);
+
+    private static async Task<ExpenseDto> CreateExpenseAsync(HttpClient client, string title, string description)
+    {
+        var res = await client.PostAsync($"/api/Expense?title={title}&description={description}", null);
+        res.StatusCode.Should().Be(HttpStatusCode.OK, await res.Content.ReadAsStringAsync());
+        return (await res.Content.ReadFromJsonAsync<ExpenseDto>())!;
+    }
+
+    [Fact]
+    public async Task Create_then_list_returns_only_the_users_expenses()
+    {
+        var user = await RegisterAndLoginAsync("crud");
+
+        await CreateExpenseAsync(user.Client, "Coffee", "Morning coffee");
+        await CreateExpenseAsync(user.Client, "Lunch", "Team lunch");
+
+        var list = await user.Client.GetFromJsonAsync<ExpenseList>("/api/Expense?pageNumber=1&pageSize=50");
+        list!.Expenses.Should().HaveCount(2);
+        list.Expenses.Select(e => e.Title).Should().Contain(new[] { "Coffee", "Lunch" });
+    }
+
+    [Fact]
+    public async Task Get_by_id_returns_the_expense()
+    {
+        var user = await RegisterAndLoginAsync("getid");
+        var created = await CreateExpenseAsync(user.Client, "Taxi", "Airport taxi");
+
+        var res = await user.Client.GetAsync($"/api/Expense/{created.Id}");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var fetched = await res.Content.ReadFromJsonAsync<ExpenseDto>();
+        fetched!.Title.Should().Be("Taxi");
+    }
+
+    [Fact]
+    public async Task Update_changes_title_description_and_category()
+    {
+        var user = await RegisterAndLoginAsync("upd");
+        var created = await CreateExpenseAsync(user.Client, "Old", "Old desc");
+
+        var res = await user.Client.PutAsJsonAsync($"/api/Expense/{created.Id}",
+            new UpdateExpenseDto(created.Id, "New", "New desc", "Travel"));
+
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await res.Content.ReadFromJsonAsync<ExpenseDto>();
+        updated!.Title.Should().Be("New");
+        updated.Category.Should().Be("Travel");
+    }
+
+    [Fact]
+    public async Task AddUser_then_getAssignedUsers_lists_creator_and_peer()
+    {
+        var user = await RegisterAndLoginAsync("assign");
+        var peer = await CreateBusinessUserAsync("peer");
+        var created = await CreateExpenseAsync(user.Client, "Dinner", "Shared dinner");
+
+        var add = await user.Client.PostAsync($"/api/Expense/{created.Id}/addUser?userId={peer.Id}", null);
+        add.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var res = await user.Client.GetAsync($"/api/Expense/{created.Id}/getAssignedUsers");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var users = await res.Content.ReadFromJsonAsync<List<JsonElement>>();
+        // Creator is auto-assigned on create, plus the peer we just added.
+        users!.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Delete_removes_expense_and_second_delete_is_not_found()
+    {
+        var user = await RegisterAndLoginAsync("del");
+        // Seed a bare expense (no split rows) so the delete isn't blocked by child references.
+        var expenseId = Guid.NewGuid();
+        await WithDbAsync(async db =>
+        {
+            SeedData.AddExpense(db, user.Id, "Temp", 10m, "Misc", DateTime.UtcNow);
+            var e = db.Expenses.Local.First();
+            expenseId = e.Id;
+            await db.SaveChangesAsync();
+        });
+
+        var first = await user.Client.DeleteAsync($"/api/Expense/{expenseId}");
+        first.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var second = await user.Client.DeleteAsync($"/api/Expense/{expenseId}");
+        second.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Count_endpoint_returns_ok()
+    {
+        var user = await RegisterAndLoginAsync("count");
+        await CreateExpenseAsync(user.Client, "One", "First");
+
+        var res = await user.Client.GetAsync("/api/Expense/count");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await res.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("totalRows").GetInt32().Should().BeGreaterThan(0);
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/FriendsNotificationTests.cs
+++ b/Tests/Expense.API.IntegrationTests/FriendsNotificationTests.cs
@@ -1,0 +1,72 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Expense.API.IntegrationTests.Infrastructure;
+using Expense.API.Models.Domain;
+using Expense.API.Models.DTO;
+using FluentAssertions;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+public class FriendsNotificationTests : IntegrationTestBase
+{
+    public FriendsNotificationTests(CustomWebAppFactory factory) : base(factory) { }
+
+    [Fact]
+    public async Task Friends_search_finds_user_by_email()
+    {
+        var user = await RegisterAndLoginAsync("friend");
+        var anon = Factory.CreateClient(); // NOTE: FriendsController has no [Authorize] — anonymous lookup works.
+
+        var res = await anon.GetAsync($"/api/Friends/{user.Email}");
+
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await res.Content.ReadFromJsonAsync<UserDto>();
+        dto!.Username.Should().Be(user.UserName);
+    }
+
+    [Fact]
+    public async Task Friends_search_returns_not_found_for_unknown_user()
+    {
+        var res = await Factory.CreateClient().GetAsync($"/api/Friends/{Unique("ghost")}");
+        res.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Notifications_lists_the_current_users_notifications()
+    {
+        var user = await RegisterAndLoginAsync("notif");
+        await WithDbAsync(async db =>
+        {
+            db.Notification.Add(new Notification
+            {
+                Id = Guid.NewGuid(),
+                UserId = user.Id,
+                Message = "Your receipt was processed",
+                Title = "Receipt ready",
+                IsRead = 0,
+                IsFriendRequest = 0,
+                CreatedAt = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync();
+        });
+
+        var res = await user.Client.GetAsync("/api/Notification");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await res.Content.ReadFromJsonAsync<List<JsonElement>>();
+        items!.Should().HaveCountGreaterThanOrEqualTo(1);
+
+        var readAll = await user.Client.PostAsync("/api/Notification/readAll", null);
+        readAll.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Notifications_anonymous_is_not_properly_guarded()
+    {
+        // SECURITY GAP: NotificationController has no [Authorize]; anonymous access is not rejected
+        // with 401 but instead surfaces as a 500 from the repository throwing "User not found".
+        var res = await Factory.CreateClient().GetAsync("/api/Notification");
+        res.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/Infrastructure/ApiCollection.cs
+++ b/Tests/Expense.API.IntegrationTests/Infrastructure/ApiCollection.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace Expense.API.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// All test classes join this collection so they share a single set of containers
+/// (built once) and run sequentially, avoiding cross-test database contention.
+/// Per-test isolation is achieved by giving every test its own unique users.
+/// </summary>
+[CollectionDefinition("Api")]
+public class ApiCollection : ICollectionFixture<CustomWebAppFactory>
+{
+}

--- a/Tests/Expense.API.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/Tests/Expense.API.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -1,0 +1,89 @@
+using System.Net.Http.Json;
+using Expense.API.Data;
+using Expense.API.Models.Domain;
+using Expense.API.Models.DTO;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Expense.API.IntegrationTests.Infrastructure;
+
+/// <summary>A user that has been registered + logged in; the client carries its jwtToken cookie.</summary>
+public record TestUser(Guid Id, string UserName, string Email, string Password, HttpClient Client);
+
+[Collection("Api")]
+public abstract class IntegrationTestBase
+{
+    protected readonly CustomWebAppFactory Factory;
+
+    protected IntegrationTestBase(CustomWebAppFactory factory) => Factory = factory;
+
+    protected static string Unique(string prefix) => $"{prefix}_{Guid.NewGuid():N}".Substring(0, prefix.Length + 9);
+
+    /// <summary>Runs an action against a scoped business DbContext.</summary>
+    protected async Task WithDbAsync(Func<UserDocumentsDbContext, Task> action)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<UserDocumentsDbContext>();
+        await action(db);
+    }
+
+    /// <summary>
+    /// Registers a user through the real API (which also creates the business Users row, required
+    /// because a role is supplied) and logs in, returning a client whose cookie is authenticated.
+    /// </summary>
+    protected async Task<TestUser> RegisterAndLoginAsync(string? namePrefix = null)
+    {
+        var userName = Unique(namePrefix ?? "user");
+        var email = $"{userName}@test.local";
+        const string password = "Passw0rd!";
+        var client = Factory.CreateClient();
+
+        var register = await client.PostAsJsonAsync("/api/Auth/Register", new RegisterRequestDto
+        {
+            Email = email,
+            UserName = userName,
+            Password = password,
+            Roles = new[] { "Writer" }
+        });
+        register.IsSuccessStatusCode.Should().BeTrue(
+            $"register should succeed but returned {(int)register.StatusCode}: {await register.Content.ReadAsStringAsync()}");
+
+        var login = await client.PostAsJsonAsync("/api/Auth/Login", new LoginRequestDto
+        {
+            Username = userName,
+            Password = password
+        });
+        login.IsSuccessStatusCode.Should().BeTrue(
+            $"login should succeed but returned {(int)login.StatusCode}: {await login.Content.ReadAsStringAsync()}");
+
+        Guid id = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var user = await db.Users.FirstOrDefaultAsync(u => u.Username == userName);
+            user.Should().NotBeNull("registration must create a matching business Users row");
+            id = user!.Id;
+        });
+
+        return new TestUser(id, userName, email, password, client);
+    }
+
+    /// <summary>Inserts a business-DB user directly (a counterparty who never needs to log in).</summary>
+    protected async Task<User> CreateBusinessUserAsync(string namePrefix = "peer")
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Username = Unique(namePrefix),
+            Email = $"{Unique(namePrefix)}@test.local",
+            CreatedAt = DateTime.UtcNow
+        };
+        await WithDbAsync(async db =>
+        {
+            db.Users.Add(user);
+            await db.SaveChangesAsync();
+        });
+        return user;
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/Infrastructure/RestrictCascadeModelCustomizer.cs
+++ b/Tests/Expense.API.IntegrationTests/Infrastructure/RestrictCascadeModelCustomizer.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Expense.API.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// The business EF model has several overlapping cascade-delete paths (Documents, DocumentJobResults,
+/// ExpenseUsers, Notifications and FriendRequests all cascade toward Users/Expenses), which SQL Server
+/// rejects when it materialises the schema ("may cause cycles or multiple cascade paths"). Production
+/// never hits this because the real database is provisioned from hand-written DDL, but our test host
+/// creates the schema from the model via EnsureCreated. This customizer downgrades every foreign key
+/// to a non-cascading delete so the schema can be created; tests never rely on DB-side cascade deletes.
+/// </summary>
+public class RestrictCascadeModelCustomizer : RelationalModelCustomizer
+{
+    public RestrictCascadeModelCustomizer(ModelCustomizerDependencies dependencies) : base(dependencies) { }
+
+    public override void Customize(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.Customize(modelBuilder, context);
+
+        foreach (var fk in modelBuilder.Model.GetEntityTypes().SelectMany(e => e.GetForeignKeys()))
+        {
+            fk.DeleteBehavior = DeleteBehavior.Restrict;
+        }
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/Infrastructure/SeedData.cs
+++ b/Tests/Expense.API.IntegrationTests/Infrastructure/SeedData.cs
@@ -1,0 +1,57 @@
+using Expense.API.Data;
+using Expense.API.Models.Domain;
+using ExpenseModel = Expense.API.Models.Domain.Expense;
+
+namespace Expense.API.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Small builders for inserting realistic business data (expenses, receipts, splits) that light up
+/// the dashboard aggregations in ExpenseRepository. Operate on a tracked DbContext; the caller saves.
+/// </summary>
+public static class SeedData
+{
+    public static ExpenseModel AddExpense(UserDocumentsDbContext db, Guid createdById, string title,
+        decimal amount, string? category, DateTime createdAt)
+    {
+        var expense = new ExpenseModel
+        {
+            Id = Guid.NewGuid(),
+            Title = title,
+            Description = $"{title} description",
+            Amount = amount,
+            Category = category,
+            CreatedById = createdById,
+            CreatedAt = createdAt
+        };
+        db.Expenses.Add(expense);
+        return expense;
+    }
+
+    public static Document AddReceipt(UserDocumentsDbContext db, Guid userId, Guid expenseId, DateTime uploadedAt)
+    {
+        var doc = new Document
+        {
+            Id = Guid.NewGuid(),
+            FileName = $"receipt-{Guid.NewGuid():N}.pdf",
+            FileExtension = ".pdf",
+            S3Url = "https://example.com/receipt",
+            ETag = "etag",
+            VersionId = "v1",
+            Size = 1024,
+            UploadedAt = uploadedAt,
+            UserId = userId,
+            ExpenseId = expenseId
+        };
+        db.Documents.Add(doc);
+        return doc;
+    }
+
+    /// <summary>A user's split on an expense: UserAmount is what dashboard owe/balance sums use.</summary>
+    public static ExpenseUser AddShare(UserDocumentsDbContext db, Guid expenseId, Guid userId,
+        double userAmount, double userShare = 0.5)
+    {
+        var share = new ExpenseUser(expenseId, userId, userAmount) { UserShare = userShare };
+        db.ExpenseUsers.Add(share);
+        return share;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,9 +91,13 @@ services:
       - expense-network
 
   frontend:
-    image: expense-analyser:latest # Pre-build frontend image 
+    image: expense-analyser:latest # Pre-build frontend image
     ports:
       - "8080:80" # Frontend exposed on port 8080
+    environment:
+      # nginx.conf proxies /api to this; without it nginx fails at boot
+      # with: [emerg] unknown "backend_api_url" variable
+      - BACKEND_API_URL=http://backend-server:80
     depends_on:
       - backend-server # Wait for API to be up
     networks:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,111 @@
+# Testing the ExpenseApi endpoints
+
+This repo has two complementary ways to test the API endpoints with realistic data:
+
+1. **Automated xUnit integration tests** (`Tests/Expense.API.IntegrationTests`) — spin up real
+   SQL Server + Redis in containers, boot the actual app, and assert endpoint behavior. CI-friendly.
+2. **A manual seed + HTTP harness** (`ExpenseAnalyserDbScripts/seed-data.sql` + `requests.http`) —
+   load realistic data into a running instance and eyeball the responses.
+
+Both were added together; the automated suite is the primary gate.
+
+---
+
+## 1. Automated integration tests
+
+### Run them
+
+```bash
+dotnet test Tests/Expense.API.IntegrationTests/Expense.API.IntegrationTests.csproj
+```
+
+Requires **Docker running** (Testcontainers starts the databases) and the **.NET 7 SDK**.
+First run pulls the SQL Server + Redis images. Current status: **28 tests, all passing (~5 s** after
+the containers are warm; the first run also pays container startup).
+
+### How the test host works (`CustomWebAppFactory`)
+
+- Boots the real `Program.cs` via `WebApplicationFactory<Program>` (a `public partial class Program`
+  marker was added to `Program.cs` so the test project can reference the entry point).
+- Starts **one SQL Server container** (hosting both `AuthenticationDb` and `ExpenseAnalyserDb`) and
+  **one Redis container**. Connection strings + JWT + AWS config are injected as environment
+  variables *before* the host builds, because `Program.cs` connects to Redis eagerly at startup.
+- **AWS is mocked**: `IAmazonS3` and `IAmazonTextract` are replaced with Moq mocks, so AWS-backed
+  endpoints are covered without credentials. The background `TextractPollingRepository` hosted
+  service is removed so it doesn't hammer the mock.
+- Schemas are created from EF: `MigrateAsync()` for the Identity DB (existing migration, seeds the
+  Reader/Writer/Admin roles) and `EnsureCreatedAsync()` for the business DB.
+- Test classes share one set of containers (`[Collection("Api")]`) and run sequentially; **isolation
+  comes from giving every test unique users** rather than resetting the DB.
+
+### Auth in tests
+
+Tests use the **real** flow: `RegisterAndLoginAsync` calls `POST /api/Auth/Register` (with a role —
+required, or the business `Users` row isn't created) then `POST /api/Auth/Login`. The JWT is
+delivered as the `jwtToken` **cookie** (not a bearer header), and the `HttpClient` cookie container
+resends it automatically.
+
+### What's covered
+
+| Area | File | Highlights |
+|------|------|-----------|
+| Auth | `AuthTests.cs` | register (with/without role), duplicate email, login, wrong password, checkSession, protected-endpoint 401 |
+| Expense CRUD | `ExpenseCrudTests.cs` | create/list (user-scoped)/get/update/delete/addUser/getAssignedUsers/count |
+| **Dashboard** | `DashboardTests.cs` | exact-number assertions for `summary`, `monthly`, `balances` over a seeded multi-user scenario, plus empty-state and 401 |
+| Friends & Notifications | `FriendsNotificationTests.cs` | user search, notification list + readAll, and the missing-auth gaps |
+| AWS (mocked) | `AwsEndpointTests.cs` | S3 list-buckets happy path, authorization gates on every AWS endpoint |
+
+The dashboard scenario (see `SeedData.cs` + `DashboardTests.cs`) seeds three users with expenses
+across categories and months, receipts, and splits in both owe directions, then asserts the exact
+aggregates (`TotalSpent`, `Categories` ordering, `YouOwe`/`OwedToYou`, monthly series, balances).
+
+---
+
+## 2. Manual seed + HTTP harness
+
+Use this to drive a live instance (docker-compose or `dotnet run`).
+
+### Steps
+
+1. **Start the stack** and create the business schema. With docker-compose the databases come up on
+   `localhost:1433` / `localhost:1434`; apply the DDL scripts in `ExpenseAnalyserDbScripts/` in order
+   (`01`–`07`, `09`) against `ExpenseAnalyserDb` (there is no `08`).
+2. **Register the primary user** by running the *Auth* section of `requests.http` (creates the
+   Identity account **and** the business `Users` row for `alice`).
+3. **Seed transactional data**: run `ExpenseAnalyserDbScripts/seed-data.sql`. It finds `alice`,
+   creates counterparties `bob`/`carol`, and inserts expenses/receipts/splits. It is idempotent
+   (clears transactional rows and reseeds) — safe only on a test database.
+4. **Exercise endpoints** with `requests.http` (VS Code REST Client or JetBrains HTTP client). The
+   Dashboard section documents the expected numbers from the seed:
+
+   | Endpoint | Expected (from seed) |
+   |----------|----------------------|
+   | `GET /api/Expense/summary?period=month` | TotalSpent **495.50**, ReceiptsScanned **2**, YouOwe **45**, OwedToYou **150**, Categories: Travel 300, Groceries 120.50, Dining 45, Other 30 |
+   | `GET /api/Expense/monthly?months=6` | current **495.50**, −1 **80**, −2 **150**, −3 **60**, else 0 |
+   | `GET /api/Expense/balances` | OwedToYou [bob 100, carol 50]; YouOwe [bob 45] |
+
+The DDL + seed + these aggregates were validated end-to-end against SQL Server 2022.
+
+---
+
+## Fixes and quirks discovered while adding tests
+
+These were found while building the tests. The DDL fixes are applied; the rest are **documented, not
+changed** (they affect production behavior and were out of scope):
+
+- **DDL fixed** — `ExpenseAnalyserDbScripts/05-expense_users.sql` was missing the `UserShare` and
+  `UserAmount` columns that the domain model and every dashboard query use; they were added. The
+  database name was inconsistent (`ExpenseAnalyser` vs `ExpenseAnalyserDb`); all scripts now use
+  `ExpenseAnalyserDb`.
+- **EF model cascade cycles** — the business model has overlapping cascade-delete paths
+  (Documents/DocumentJobResults/ExpenseUsers/Notifications/FriendRequests → Users/Expenses) that
+  SQL Server rejects on `EnsureCreated` ("may cause cycles or multiple cascade paths"). Production
+  never hits this because it uses raw DDL; the test host works around it with
+  `RestrictCascadeModelCustomizer` (downgrades FKs to non-cascading) **for tests only**.
+- **Routing quirk** — the S3 controller's route resolves to **`/api/S/list-buckets`**, not
+  `/api/S3/...` (the `[controller]` token yields `S`). A client calling `/api/S3/...` will 404.
+- **Missing `[Authorize]`** — `FriendsController` and `NotificationController` are ungated, and
+  `DELETE /api/Document/{id}` is anonymous. They don't return 401; they either serve data
+  (Friends search) or throw and surface as 500 (Notifications, Document delete). Encoded as tests
+  so the behavior is visible.
+- **`GET /api/Expense/count`** returns a **global** expense count, not the current user's.

--- a/requests.http
+++ b/requests.http
@@ -1,0 +1,114 @@
+### ExpenseApi endpoint smoke tests (VS Code REST Client / JetBrains .http)
+#
+# Auth is a `jwtToken` cookie set by Login; REST clients persist and resend cookies
+# per host automatically, so run Register -> Login once, then the rest just work.
+#
+# @baseUrl points at the docker-compose backend (http, no HTTPS redirect). For a local
+# `dotnet run`, HTTPS redirect is on — use https://localhost:7085 instead.
+#
+# For meaningful dashboard numbers: run the schema scripts, then Register alice below,
+# then run ExpenseAnalyserDbScripts/seed-data.sql, then hit the Dashboard section.
+@baseUrl = http://localhost:5223
+@user = alice
+@password = Passw0rd!
+
+### ---------------------------------------------------------------- Auth
+# @name register
+POST {{baseUrl}}/api/Auth/Register
+Content-Type: application/json
+
+{
+  "email": "{{user}}@test.local",
+  "userName": "{{user}}",
+  "password": "{{password}}",
+  "roles": ["Writer"]
+}
+
+### Login (sets the jwtToken cookie used by every request below)
+# @name login
+POST {{baseUrl}}/api/Auth/Login
+Content-Type: application/json
+
+{
+  "username": "{{user}}",
+  "password": "{{password}}"
+}
+
+### Session check (should report isLoggedIn: true after login)
+GET {{baseUrl}}/api/Auth/checkSession
+
+### ---------------------------------------------------------- Dashboard
+# Expected values below assume seed-data.sql was applied for user alice.
+
+### Summary — TotalSpent 495.50, ReceiptsScanned 2, YouOwe 45, OwedToYou 150
+GET {{baseUrl}}/api/Expense/summary?period=month
+
+### Monthly — current 495.50, -1 80, -2 150, -3 60, else 0
+GET {{baseUrl}}/api/Expense/monthly?months=6
+
+### Balances — OwedToYou [bob 100, carol 50]; YouOwe [bob 45]
+GET {{baseUrl}}/api/Expense/balances
+
+### ------------------------------------------------------- Expense CRUD
+### Create an expense (title + description are query params; amount defaults to 0)
+# @name createExpense
+POST {{baseUrl}}/api/Expense?title=Coffee&description=Morning coffee
+
+### List my expenses (paged)
+GET {{baseUrl}}/api/Expense?pageNumber=1&pageSize=50
+
+### Count (note: returns a global count, not per-user)
+GET {{baseUrl}}/api/Expense/count
+
+### Get one by id
+GET {{baseUrl}}/api/Expense/{{createExpense.response.body.id}}
+
+### Assigned users (creator is auto-assigned on create)
+GET {{baseUrl}}/api/Expense/{{createExpense.response.body.id}}/getAssignedUsers
+
+### Update
+PUT {{baseUrl}}/api/Expense/{{createExpense.response.body.id}}
+Content-Type: application/json
+
+{
+  "id": "{{createExpense.response.body.id}}",
+  "title": "Coffee (updated)",
+  "description": "Updated description",
+  "category": "Dining"
+}
+
+### Shared-with-me expenses
+GET {{baseUrl}}/api/Expense/sharedExpenses?pageNumber=1&pageSize=50
+
+### Dropdown
+GET {{baseUrl}}/api/Expense/dropdown
+
+### Delete
+DELETE {{baseUrl}}/api/Expense/{{createExpense.response.body.id}}
+
+### ----------------------------------------------------------- Friends
+### Search a user by email or username (NOTE: no [Authorize] on this controller)
+GET {{baseUrl}}/api/Friends/{{user}}@test.local
+
+### Friends list
+GET {{baseUrl}}/api/Friends/getFriends
+
+### Dropdown users
+GET {{baseUrl}}/api/Friends/getDropdownUsers
+
+### ------------------------------------------------------ Notifications
+### List my notifications
+GET {{baseUrl}}/api/Notification
+
+### Mark all read
+POST {{baseUrl}}/api/Notification/readAll
+
+### ------------------------------------------------------------ AWS (S3)
+### List buckets — NOTE the route is /api/S/list-buckets, not /api/S3/...
+GET {{baseUrl}}/api/S/list-buckets
+
+### Downloadable links for the current user
+GET {{baseUrl}}/api/Document/downloadLinks
+
+### --------------------------------------------------------------- Logout
+POST {{baseUrl}}/api/Auth/Logout


### PR DESCRIPTION
Add three GET endpoints under api/Expense to power the frontend dashboard homescreen, following the Controller -> IExpenseRepository -> DbContext layering:

- GET summary?period=month|quarter|year — total spent (+ delta vs previous comparable period), receipts scanned, you-owe / owed-to-you, and a spending-by-category breakdown.
- GET monthly?months=N — SUM(Amount) per month with gap months filled to 0.
- GET balances — gross outstanding amounts per counterparty, by direction.

Add a nullable Category column to Expense (entity + manual SQL script 09-add-expense-category.sql; null buckets into "Other") and carry it through the create/update DTOs. Introduce dashboard DTOs and a GetCurrentUserAsync helper resolving the user from the JWT NameIdentifier claim.