### PR TITLE
routine(B2): Net balances + per-counterparty balance detail

### DIFF
--- a/Controllers/ExpenseController.cs
+++ b/Controllers/ExpenseController.cs
@@ -336,6 +336,25 @@ namespace Expense.API.Controllers
             }
         }
 
+        // GET: api/Expense/balances/{userId}
+        [HttpGet("balances/{userId}")]
+        public async Task<IActionResult> GetBalanceDetail(Guid userId)
+        {
+            try
+            {
+                var detail = await expenseRepository.GetBalanceDetailAsync(userId);
+                if (detail == null)
+                {
+                    return NotFound($"User not found: {userId}");
+                }
+                return Ok(detail);
+            }
+            catch (Exception e)
+            {
+                return BadRequest($"An error occurred: {e.Message}");
+            }
+        }
+
         [Authorize]
         [HttpGet("{expenseId}/doc/{docId}")]
         public async Task<IActionResult> GetResults(string expenseId, string docId)

--- a/Models/DTO/BalanceDetailDto.cs
+++ b/Models/DTO/BalanceDetailDto.cs
@@ -1,0 +1,36 @@
+namespace Expense.API.Models.DTO
+{
+    /// <summary>
+    /// Net balance with a single counterparty plus the chronological ledger (expenses + settlements)
+    /// that makes it up.
+    /// </summary>
+    public class BalanceDetailDto
+    {
+        public Guid UserId { get; set; }
+        public string UserName { get; set; }
+
+        /// <summary>Absolute net amount outstanding between the caller and this counterparty.</summary>
+        public double NetAmount { get; set; }
+
+        /// <summary>"youOwe" | "owedToYou" | "settled", relative to the caller.</summary>
+        public string Direction { get; set; }
+
+        /// <summary>Chronological (oldest first) expense shares and settlements between the two users.</summary>
+        public List<BalanceDetailEntryDto> Entries { get; set; } = new();
+    }
+
+    public class BalanceDetailEntryDto
+    {
+        /// <summary>"expense" | "settlement".</summary>
+        public string Type { get; set; }
+
+        public Guid Id { get; set; }
+        public string Description { get; set; }
+        public double Amount { get; set; }
+
+        /// <summary>"youOwe" | "owedToYou", relative to the caller.</summary>
+        public string Direction { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Repositories/Expense/ExpenseRepository.cs
+++ b/Repositories/Expense/ExpenseRepository.cs
@@ -377,13 +377,9 @@ namespace Expense.API.Repositories.Expense
             var receiptsScanned = await userDocumentsDbContext.Documents
                 .CountAsync(d => d.UserId == user.Id && d.UploadedAt >= from && d.UploadedAt <= to);
 
-            var youOwe = await userDocumentsDbContext.ExpenseUsers
-                .Where(eu => eu.UserId == user.Id && eu.Expense.CreatedById != user.Id)
-                .SumAsync(eu => eu.UserAmount) ?? 0.0;
-
-            var owedToYou = await userDocumentsDbContext.ExpenseUsers
-                .Where(eu => eu.Expense.CreatedById == user.Id && eu.UserId != user.Id)
-                .SumAsync(eu => eu.UserAmount) ?? 0.0;
+            var netBalances = await GetNetBalancesByCounterpartyAsync(user.Id);
+            var youOwe = netBalances.Values.Where(v => v < 0).Sum(v => -v);
+            var owedToYou = netBalances.Values.Where(v => v > 0).Sum(v => v);
 
             var categoriesRaw = await myExpensesInWindow
                 .GroupBy(e => e.Category)
@@ -439,44 +435,144 @@ namespace Expense.API.Repositories.Expense
         public async Task<OutstandingBalancesDto> GetOutstandingBalancesAsync()
         {
             var user = await GetCurrentUserAsync();
-
-            // People I owe: my shares on expenses created by others, grouped by the creator.
-            var youOweRaw = await userDocumentsDbContext.ExpenseUsers
-                .Where(eu => eu.UserId == user.Id && eu.Expense.CreatedById != user.Id)
-                .GroupBy(eu => eu.Expense.CreatedById)
-                .Select(g => new { CounterpartyId = g.Key, Amount = g.Sum(eu => eu.UserAmount) })
-                .ToListAsync();
-
-            // People who owe me: others' shares on expenses I created, grouped by the sharer.
-            var owedToYouRaw = await userDocumentsDbContext.ExpenseUsers
-                .Where(eu => eu.Expense.CreatedById == user.Id && eu.UserId != user.Id)
-                .GroupBy(eu => eu.UserId)
-                .Select(g => new { CounterpartyId = g.Key, Amount = g.Sum(eu => eu.UserAmount) })
-                .ToListAsync();
-
-            var ids = youOweRaw.Select(x => x.CounterpartyId)
-                .Concat(owedToYouRaw.Select(x => x.CounterpartyId))
-                .Distinct()
-                .ToList();
+            var netBalances = await GetNetBalancesByCounterpartyAsync(user.Id);
 
             var names = await userDocumentsDbContext.Users
-                .Where(u => ids.Contains(u.Id))
+                .Where(u => netBalances.Keys.Contains(u.Id))
                 .ToDictionaryAsync(u => u.Id, u => u.Username);
 
-            List<BalanceEntryDto> Project(IEnumerable<dynamic> rows) => rows
-                .Select(r => new BalanceEntryDto
-                {
-                    UserId = r.CounterpartyId,
-                    UserName = names.TryGetValue((Guid)r.CounterpartyId, out string n) ? n : "Unknown",
-                    Amount = (double)(r.Amount ?? 0.0)
-                })
+            string NameOf(Guid counterpartyId) => names.TryGetValue(counterpartyId, out var n) ? n : "Unknown";
+
+            var youOwe = netBalances
+                .Where(kv => kv.Value < 0)
+                .Select(kv => new BalanceEntryDto { UserId = kv.Key, UserName = NameOf(kv.Key), Amount = -kv.Value })
+                .OrderByDescending(b => b.Amount)
+                .ToList();
+
+            var owedToYou = netBalances
+                .Where(kv => kv.Value > 0)
+                .Select(kv => new BalanceEntryDto { UserId = kv.Key, UserName = NameOf(kv.Key), Amount = kv.Value })
                 .OrderByDescending(b => b.Amount)
                 .ToList();
 
             return new OutstandingBalancesDto
             {
-                YouOwe = Project(youOweRaw),
-                OwedToYou = Project(owedToYouRaw)
+                YouOwe = youOwe,
+                OwedToYou = owedToYou
+            };
+        }
+
+        /// <summary>
+        /// Net amount owed with every counterparty the user has an expense share or settlement with:
+        /// positive = counterparty owes the user, negative = the user owes the counterparty, 0 = settled.
+        /// Nets expense shares against settlements paid in either direction.
+        /// </summary>
+        private async Task<Dictionary<Guid, double>> GetNetBalancesByCounterpartyAsync(Guid userId)
+        {
+            // My shares on expenses created by others, grouped by the creator (money I owe from expenses).
+            var oweFromExpenses = (await userDocumentsDbContext.ExpenseUsers
+                .Where(eu => eu.UserId == userId && eu.Expense.CreatedById != userId)
+                .GroupBy(eu => eu.Expense.CreatedById)
+                .Select(g => new { CounterpartyId = g.Key, Amount = g.Sum(eu => eu.UserAmount) ?? 0.0 })
+                .ToListAsync())
+                .ToDictionary(x => x.CounterpartyId, x => x.Amount);
+
+            // Others' shares on expenses I created, grouped by the sharer (money owed to me from expenses).
+            var owedFromExpenses = (await userDocumentsDbContext.ExpenseUsers
+                .Where(eu => eu.Expense.CreatedById == userId && eu.UserId != userId)
+                .GroupBy(eu => eu.UserId)
+                .Select(g => new { CounterpartyId = g.Key, Amount = g.Sum(eu => eu.UserAmount) ?? 0.0 })
+                .ToListAsync())
+                .ToDictionary(x => x.CounterpartyId, x => x.Amount);
+
+            // Settlements I paid to each counterparty (reduces what I owe them).
+            var settlementsIPaid = (await userDocumentsDbContext.Settlements
+                .Where(s => s.PayerId == userId)
+                .GroupBy(s => s.PayeeId)
+                .Select(g => new { CounterpartyId = g.Key, Amount = g.Sum(s => s.Amount) })
+                .ToListAsync())
+                .ToDictionary(x => x.CounterpartyId, x => (double)x.Amount);
+
+            // Settlements each counterparty paid me (reduces what they owe me).
+            var settlementsTheyPaid = (await userDocumentsDbContext.Settlements
+                .Where(s => s.PayeeId == userId)
+                .GroupBy(s => s.PayerId)
+                .Select(g => new { CounterpartyId = g.Key, Amount = g.Sum(s => s.Amount) })
+                .ToListAsync())
+                .ToDictionary(x => x.CounterpartyId, x => (double)x.Amount);
+
+            var counterpartyIds = oweFromExpenses.Keys
+                .Concat(owedFromExpenses.Keys)
+                .Concat(settlementsIPaid.Keys)
+                .Concat(settlementsTheyPaid.Keys)
+                .Distinct();
+
+            var net = new Dictionary<Guid, double>();
+            foreach (var counterpartyId in counterpartyIds)
+            {
+                var owed = owedFromExpenses.GetValueOrDefault(counterpartyId)
+                    - settlementsTheyPaid.GetValueOrDefault(counterpartyId);
+                var owe = oweFromExpenses.GetValueOrDefault(counterpartyId)
+                    - settlementsIPaid.GetValueOrDefault(counterpartyId);
+                net[counterpartyId] = owed - owe;
+            }
+            return net;
+        }
+
+        public async Task<BalanceDetailDto?> GetBalanceDetailAsync(Guid counterpartyId)
+        {
+            var user = await GetCurrentUserAsync();
+
+            var counterparty = await userDocumentsDbContext.Users.FirstOrDefaultAsync(u => u.Id == counterpartyId);
+            if (counterparty == null)
+            {
+                return null;
+            }
+
+            var expenseEntries = await userDocumentsDbContext.ExpenseUsers
+                .Where(eu =>
+                    (eu.UserId == user.Id && eu.Expense.CreatedById == counterpartyId) ||
+                    (eu.UserId == counterpartyId && eu.Expense.CreatedById == user.Id))
+                .Select(eu => new BalanceDetailEntryDto
+                {
+                    Type = "expense",
+                    Id = eu.ExpenseId,
+                    Description = eu.Expense.Title,
+                    Amount = eu.UserAmount ?? 0.0,
+                    Direction = eu.UserId == user.Id ? "youOwe" : "owedToYou",
+                    CreatedAt = eu.Expense.CreatedAt
+                })
+                .ToListAsync();
+
+            var settlementEntries = await userDocumentsDbContext.Settlements
+                .Where(s =>
+                    (s.PayerId == user.Id && s.PayeeId == counterpartyId) ||
+                    (s.PayerId == counterpartyId && s.PayeeId == user.Id))
+                .Select(s => new BalanceDetailEntryDto
+                {
+                    Type = "settlement",
+                    Id = s.Id,
+                    Description = s.Note ?? "Settlement",
+                    Amount = (double)s.Amount,
+                    Direction = s.PayerId == user.Id ? "youOwe" : "owedToYou",
+                    CreatedAt = s.CreatedAt
+                })
+                .ToListAsync();
+
+            var entries = expenseEntries.Concat(settlementEntries)
+                .OrderBy(e => e.CreatedAt)
+                .ToList();
+
+            var netBalances = await GetNetBalancesByCounterpartyAsync(user.Id);
+            var net = netBalances.GetValueOrDefault(counterpartyId);
+
+            return new BalanceDetailDto
+            {
+                UserId = counterparty.Id,
+                UserName = counterparty.Username,
+                NetAmount = Math.Abs(net),
+                Direction = net > 0 ? "owedToYou" : net < 0 ? "youOwe" : "settled",
+                Entries = entries
             };
         }
     }

--- a/Repositories/Expense/IExpenseRepository.cs
+++ b/Repositories/Expense/IExpenseRepository.cs
@@ -101,9 +101,17 @@ namespace Expense.API.Repositories.Expense
         public Task<List<MonthlySpendingDto>> GetMonthlySpendingAsync(int months);
 
         /// <summary>
-        /// Dashboard outstanding balances: gross amounts owed per counterparty, split by direction.
+        /// Dashboard outstanding balances: amounts owed per counterparty (net of settlements), split
+        /// by direction.
         /// </summary>
         public Task<OutstandingBalancesDto> GetOutstandingBalancesAsync();
+
+        /// <summary>
+        /// Net balance with a single counterparty plus the chronological ledger (expense shares +
+        /// settlements) between the caller and that counterparty. Null when counterpartyId is not an
+        /// existing user.
+        /// </summary>
+        public Task<BalanceDetailDto?> GetBalanceDetailAsync(Guid counterpartyId);
 
     }
 }

--- a/Tests/Expense.API.IntegrationTests/BalanceDetailTests.cs
+++ b/Tests/Expense.API.IntegrationTests/BalanceDetailTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Net.Http.Json;
+using Expense.API.IntegrationTests.Infrastructure;
+using Expense.API.Models.DTO;
+using FluentAssertions;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+/// <summary>
+/// Exercises GET /api/Expense/balances/{userId} against a hand-built ledger and asserts the
+/// chronological entry list, directions, and the net summary. Mirrors the math in
+/// ExpenseRepository.GetBalanceDetailAsync / GetNetBalancesByCounterpartyAsync.
+/// </summary>
+public class BalanceDetailTests : IntegrationTestBase
+{
+    public BalanceDetailTests(CustomWebAppFactory factory) : base(factory) { }
+
+    [Fact]
+    public async Task Detail_returns_chronological_entries_with_directions_and_net()
+    {
+        var alice = await RegisterAndLoginAsync("baldetailalice");
+        var bob = await CreateBusinessUserAsync("baldetailbob");
+        var now = DateTime.UtcNow;
+
+        await WithDbAsync(async db =>
+        {
+            var aliceExpense = SeedData.AddExpense(db, alice.Id, "Dinner", 100m, "Dining", now.AddMinutes(-30));
+            SeedData.AddShare(db, aliceExpense.Id, bob.Id, 40); // bob owes alice 40
+
+            var bobExpense = SeedData.AddExpense(db, bob.Id, "Cab", 60m, "Travel", now.AddMinutes(-20));
+            SeedData.AddShare(db, bobExpense.Id, alice.Id, 25); // alice owes bob 25
+
+            db.Settlements.Add(new Expense.API.Models.Domain.Settlement
+            {
+                Id = Guid.NewGuid(),
+                PayerId = alice.Id,
+                PayeeId = bob.Id,
+                Amount = 25m,
+                Note = "Cab payback",
+                CreatedAt = now.AddMinutes(-10)
+            });
+
+            await db.SaveChangesAsync();
+        });
+
+        var detail = await alice.Client.GetFromJsonAsync<BalanceDetailDto>($"/api/Expense/balances/{bob.Id}");
+
+        detail!.UserId.Should().Be(bob.Id);
+        detail.UserName.Should().Be(bob.Username);
+        // bob owes alice 40 from the expense; the 25 alice owed bob was settled by her payment.
+        detail.NetAmount.Should().Be(40.0);
+        detail.Direction.Should().Be("owedToYou");
+
+        detail.Entries.Should().HaveCount(3);
+
+        detail.Entries[0].Type.Should().Be("expense");
+        detail.Entries[0].Description.Should().Be("Dinner");
+        detail.Entries[0].Direction.Should().Be("owedToYou");
+        detail.Entries[0].Amount.Should().Be(40.0);
+
+        detail.Entries[1].Type.Should().Be("expense");
+        detail.Entries[1].Description.Should().Be("Cab");
+        detail.Entries[1].Direction.Should().Be("youOwe");
+        detail.Entries[1].Amount.Should().Be(25.0);
+
+        detail.Entries[2].Type.Should().Be("settlement");
+        detail.Entries[2].Description.Should().Be("Cab payback");
+        detail.Entries[2].Direction.Should().Be("youOwe");
+        detail.Entries[2].Amount.Should().Be(25.0);
+    }
+
+    [Fact]
+    public async Task Detail_reports_settled_when_net_is_zero()
+    {
+        var alice = await RegisterAndLoginAsync("baldetailzero");
+        var bob = await CreateBusinessUserAsync("baldetailzerobob");
+        var now = DateTime.UtcNow;
+
+        await WithDbAsync(async db =>
+        {
+            var aliceExpense = SeedData.AddExpense(db, alice.Id, "Groceries", 60m, "Groceries", now);
+            SeedData.AddShare(db, aliceExpense.Id, bob.Id, 30); // bob owes alice 30
+
+            db.Settlements.Add(new Expense.API.Models.Domain.Settlement
+            {
+                Id = Guid.NewGuid(),
+                PayerId = bob.Id,
+                PayeeId = alice.Id,
+                Amount = 30m,
+                CreatedAt = now.AddMinutes(1)
+            });
+
+            await db.SaveChangesAsync();
+        });
+
+        var detail = await alice.Client.GetFromJsonAsync<BalanceDetailDto>($"/api/Expense/balances/{bob.Id}");
+
+        detail!.NetAmount.Should().Be(0.0);
+        detail.Direction.Should().Be("settled");
+        detail.Entries.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Detail_returns_not_found_for_unknown_user()
+    {
+        var alice = await RegisterAndLoginAsync("baldetailghost");
+
+        var res = await alice.Client.GetAsync($"/api/Expense/balances/{Guid.NewGuid()}");
+
+        res.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Detail_requires_authentication()
+    {
+        var res = await Factory.CreateClient().GetAsync($"/api/Expense/balances/{Guid.NewGuid()}");
+
+        res.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/DashboardTests.cs
+++ b/Tests/Expense.API.IntegrationTests/DashboardTests.cs
@@ -93,6 +93,58 @@ public class DashboardTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task Balances_net_settlements_partial_exact_and_over_settle()
+    {
+        var alice = await RegisterAndLoginAsync("netalice");
+        var bob = await CreateBusinessUserAsync("netbob");
+        var carol = await CreateBusinessUserAsync("netcarol");
+        var dave = await CreateBusinessUserAsync("netdave");
+        var now = DateTime.UtcNow;
+
+        await WithDbAsync(async db =>
+        {
+            var aliceExpense = SeedData.AddExpense(db, alice.Id, "Trip", 300m, "Travel", now);
+            SeedData.AddShare(db, aliceExpense.Id, bob.Id, 100); // bob owes alice 100
+            SeedData.AddShare(db, aliceExpense.Id, carol.Id, 60); // carol owes alice 60
+            SeedData.AddShare(db, aliceExpense.Id, dave.Id, 90); // dave owes alice 90
+
+            void AddSettlement(Guid payerId, Guid payeeId, decimal amount)
+            {
+                db.Settlements.Add(new Expense.API.Models.Domain.Settlement
+                {
+                    Id = Guid.NewGuid(),
+                    PayerId = payerId,
+                    PayeeId = payeeId,
+                    Amount = amount,
+                    CreatedAt = now
+                });
+            }
+
+            AddSettlement(bob.Id, alice.Id, 40m); // partial: bob still owes 60
+            AddSettlement(carol.Id, alice.Id, 60m); // exact: carol settled, disappears
+            AddSettlement(dave.Id, alice.Id, 150m); // over-settle: alice now owes dave 60
+
+            await db.SaveChangesAsync();
+        });
+
+        var balances = await alice.Client.GetFromJsonAsync<OutstandingBalancesDto>("/api/Expense/balances");
+
+        balances!.OwedToYou.Should().ContainSingle();
+        balances.OwedToYou[0].UserName.Should().Be(bob.Username);
+        balances.OwedToYou[0].Amount.Should().Be(60.0);
+        balances.OwedToYou.Should().NotContain(b => b.UserName == carol.Username);
+        balances.OwedToYou.Should().NotContain(b => b.UserName == dave.Username);
+
+        balances.YouOwe.Should().ContainSingle();
+        balances.YouOwe[0].UserName.Should().Be(dave.Username);
+        balances.YouOwe[0].Amount.Should().Be(60.0);
+
+        var summary = await alice.Client.GetFromJsonAsync<DashboardSummaryDto>("/api/Expense/summary?period=month");
+        summary!.OwedToYou.Should().Be(60.0);
+        summary.YouOwe.Should().Be(60.0);
+    }
+
+    [Fact]
     public async Task Monthly_returns_zero_filled_series_with_correct_amounts()
     {
         var dave = await RegisterAndLoginAsync("dave");

--- a/Tests/Expense.API.IntegrationTests/DashboardTests.cs
+++ b/Tests/Expense.API.IntegrationTests/DashboardTests.cs
@@ -36,11 +36,12 @@ public class DashboardTests : IntegrationTestBase
             SeedData.AddReceipt(db, alice.Id, travel.Id, now);
             SeedData.AddReceipt(db, alice.Id, travel.Id, now);
 
-            // Bob & Carol owe Alice on her expense: 25 + 15 = 40 (OwedToYou).
+            // Bob & Carol owe Alice on her expense: 25 + 15.
             SeedData.AddShare(db, travel.Id, bob.Id, 25);
             SeedData.AddShare(db, travel.Id, carol.Id, 15);
 
-            // Alice owes Bob 40 on an expense Bob created (YouOwe).
+            // Alice owes Bob 40 on an expense Bob created; netted against the 25 bob owes alice
+            // above, bob nets to alice owing him 15 (YouOwe) - carol's 15 stays in OwedToYou.
             var bobExpense = SeedData.AddExpense(db, bob.Id, "Concert", 80m, "Entertainment", now);
             SeedData.AddShare(db, bobExpense.Id, alice.Id, 40);
 
@@ -51,8 +52,8 @@ public class DashboardTests : IntegrationTestBase
 
         summary!.TotalSpent.Should().Be(380m);
         summary.ReceiptsScanned.Should().Be(2);
-        summary.YouOwe.Should().Be(40.0);
-        summary.OwedToYou.Should().Be(40.0);
+        summary.YouOwe.Should().Be(15.0);
+        summary.OwedToYou.Should().Be(15.0);
         summary.TotalSpentDeltaPct.Should().Be(100.0); // no prior-period spend
         summary.Categories.Should().HaveCount(4);
         summary.Categories[0].Category.Should().Be("Travel"); // highest amount first
@@ -71,9 +72,11 @@ public class DashboardTests : IntegrationTestBase
         await WithDbAsync(async db =>
         {
             var aliceExpense = SeedData.AddExpense(db, alice.Id, "Hotel", 300m, "Travel", now);
-            SeedData.AddShare(db, aliceExpense.Id, bob.Id, 120);
+            SeedData.AddShare(db, aliceExpense.Id, bob.Id, 120); // bob owes alice 120 from this expense
             SeedData.AddShare(db, aliceExpense.Id, carol.Id, 80);
 
+            // Alice owes bob 45 on a bob-created expense; netted against the 120 above, bob's
+            // position becomes a single 75 owed to alice (he no longer appears in YouOwe at all).
             var bobExpense = SeedData.AddExpense(db, bob.Id, "Rental", 90m, "Travel", now);
             SeedData.AddShare(db, bobExpense.Id, alice.Id, 45);
 
@@ -83,13 +86,11 @@ public class DashboardTests : IntegrationTestBase
         var balances = await alice.Client.GetFromJsonAsync<OutstandingBalancesDto>("/api/Expense/balances");
 
         balances!.OwedToYou.Should().HaveCount(2);
-        balances.OwedToYou[0].UserName.Should().Be(bob.Username); // 120 sorted before 80
-        balances.OwedToYou[0].Amount.Should().Be(120.0);
-        balances.OwedToYou.Should().Contain(b => b.UserName == carol.Username && b.Amount == 80.0);
+        balances.OwedToYou[0].UserName.Should().Be(carol.Username); // 80 sorted before bob's net 75
+        balances.OwedToYou[0].Amount.Should().Be(80.0);
+        balances.OwedToYou.Should().Contain(b => b.UserName == bob.Username && b.Amount == 75.0);
 
-        balances.YouOwe.Should().ContainSingle();
-        balances.YouOwe[0].UserName.Should().Be(bob.Username);
-        balances.YouOwe[0].Amount.Should().Be(45.0);
+        balances.YouOwe.Should().BeEmpty();
     }
 
     [Fact]

--- a/docs/ROUTINES_PLAN.md
+++ b/docs/ROUTINES_PLAN.md
@@ -91,7 +91,7 @@ GET  /api/Budget?period=month
 ## Phase checklist
 
 - [x] **B1 — Settlement model, repository, endpoints**
-- [ ] **B2 — Net balances + per-counterparty balance detail**
+- [x] **B2 — Net balances + per-counterparty balance detail**
 - [ ] **B3 — Settlement notification**
 - [ ] **B4 — Budget model, repository, endpoints**
 - [ ] **B5 — Budget threshold alerts**


### PR DESCRIPTION
## What was built

- **Net outstanding balances.** `ExpenseRepository.GetOutstandingBalancesAsync` now nets each counterparty's amount owed from expense shares against settlements paid in either direction, via a new private `GetNetBalancesByCounterpartyAsync(userId)` helper: `net = (owedFromExpenses − settlementsTheyPaid) − (oweFromExpenses − settlementsIPaid)`. A counterparty lands in `OwedToYou` when net > 0, `YouOwe` when net < 0, and is omitted entirely when net == 0. `GetDashboardSummaryAsync`'s `YouOwe`/`OwedToYou` totals now sum the same netted per-counterparty values, so both endpoints agree.
- **`GET /api/Expense/balances/{userId}`** (new `IExpenseRepository.GetBalanceDetailAsync` + `ExpenseController.GetBalanceDetail`): returns `BalanceDetailDto { userId, userName, netAmount, direction, entries }` — the net amount/direction (via the same helper) plus a chronological ledger combining expense shares (`type: "expense"`, description = expense title) and settlements (`type: "settlement"`, description = note or `"Settlement"`) between the caller and the counterparty. Direction on each entry is relative to the caller (`"youOwe"` when the caller is the ExpenseUser/payer side, `"owedToYou"` otherwise). Returns 404 when `{userId}` isn't an existing user (repository returns `null`, controller maps to `NotFound`, mirroring the existing `FriendsController`/`ExpenseController` null-check convention).
- New `Models/DTO/BalanceDetailDto.cs` (`BalanceDetailDto` + `BalanceDetailEntryDto`), built directly in the repository (no AutoMapper), consistent with how `OutstandingBalancesDto` is already built.

## How it was tested

- `dotnet build` — 0 errors (same pre-existing nullable-reference warnings as the rest of the codebase).
- Extended `DashboardTests.cs` with `Balances_net_settlements_partial_exact_and_over_settle`, covering: partial settle (counterparty amount reduces but stays in the same list), exact settle (counterparty disappears from both lists), and over-settle (direction flips from `OwedToYou` to `YouOwe`); also asserts the dashboard summary's `YouOwe`/`OwedToYou` totals match.
- New `BalanceDetailTests.cs`: chronological entry ordering and per-entry directions across a mixed expense+settlement ledger, `NetAmount`/`Direction` when net is 0 (`"settled"`), 404 for an unknown `userId`, and 401 without auth.

## Deviations / notes

- **Docker was available in this sandbox but image pulls were blocked by the environment's network egress policy** (`docker pull redis:7.0` → `403 Forbidden` from the registry CDN), so I could not run `dotnet test Tests/Expense.API.IntegrationTests` end-to-end here. Both new/changed test files build cleanly against the current interfaces. GitHub Actions (`.github/workflows/integration-tests.yml`) will run the full suite on this PR and is the gate of record.
- The settlement entry's `direction` isn't explicitly specified by the contract (only expense entries have `direction: "youOwe"` documented per the ledger). I used `"youOwe"` when the caller is the settlement's payer and `"owedToYou"` when the caller is the payee, so a settlement is tagged with whichever thread it's paying down — consistent with how expense entries are tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014ruqsSAk38Rnp6F2kyENSD)_