### PR TITLE
routine(B3): Settlement notification

### DIFF
--- a/Repositories/Settlement/SettlementRepository.cs
+++ b/Repositories/Settlement/SettlementRepository.cs
@@ -1,9 +1,11 @@
 using System.Security.Claims;
 using AutoMapper;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Expense.API.Data;
 using Expense.API.Models.Domain;
 using Expense.API.Models.DTO;
+using Expense.API.Repositories.Notifications;
 using SettlementModel = Expense.API.Models.Domain.Settlement;
 
 namespace Expense.API.Repositories.Settlement
@@ -13,12 +15,17 @@ namespace Expense.API.Repositories.Settlement
         private readonly UserDocumentsDbContext userDocumentsDbContext;
         private readonly IHttpContextAccessor httpContextAccessor;
         private readonly IMapper mapper;
+        private readonly IServiceProvider serviceProvider;
+        private readonly IHubContext<TextractNotificationHub> textractNotification;
 
-        public SettlementRepository(UserDocumentsDbContext userDocumentsDbContext, IHttpContextAccessor httpContextAccessor, IMapper mapper)
+        public SettlementRepository(UserDocumentsDbContext userDocumentsDbContext, IHttpContextAccessor httpContextAccessor, IMapper mapper,
+            IServiceProvider serviceProvider, IHubContext<TextractNotificationHub> textractNotification)
         {
             this.userDocumentsDbContext = userDocumentsDbContext;
             this.httpContextAccessor = httpContextAccessor;
             this.mapper = mapper;
+            this.serviceProvider = serviceProvider;
+            this.textractNotification = textractNotification;
         }
 
         /// <summary>
@@ -76,7 +83,32 @@ namespace Expense.API.Repositories.Settlement
             await userDocumentsDbContext.Settlements.AddAsync(settlement);
             await userDocumentsDbContext.SaveChangesAsync();
 
+            await NotifyPayeeAsync(payer, payee, createSettlementDto.Amount);
+
             return mapper.Map<SettlementDto>(settlement);
+        }
+
+        /// <summary>
+        /// Notify the payee that a settlement was recorded. A notification failure must not fail the settlement.
+        /// </summary>
+        private async Task NotifyPayeeAsync(User payer, User payee, decimal amount)
+        {
+            try
+            {
+                var message = $"{payer.Username} settled ${amount} with you";
+
+                using (var scope = serviceProvider.CreateScope())
+                {
+                    var textractNotificationDb = scope.ServiceProvider.GetRequiredService<ITextractNotification>();
+                    await textractNotificationDb.CreateNotifcation(payee.Id, message, "Settlement received", 0);
+                }
+
+                await textractNotification.Clients.User(payee.Username).SendAsync("TextractNotification", message);
+            }
+            catch
+            {
+                // Swallow: a notification failure must not fail the settlement.
+            }
         }
 
         public async Task<List<SettlementDto>> GetForUserAsync(int pageNumber, int pageSize)

--- a/Tests/Expense.API.IntegrationTests/SettlementTests.cs
+++ b/Tests/Expense.API.IntegrationTests/SettlementTests.cs
@@ -136,6 +136,39 @@ public class SettlementTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task Create_notifies_the_payee()
+    {
+        var alice = await RegisterAndLoginAsync("setnotifyalice");
+        var bob = await RegisterAndLoginAsync("setnotifybob");
+
+        var res = await alice.Client.PostAsJsonAsync("/api/Settlement", new CreateSettlementDto
+        {
+            PayeeUserId = bob.Id,
+            Amount = 25m,
+            Note = "coffee"
+        });
+        res.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        await WithDbAsync(async db =>
+        {
+            var notification = await db.Notification
+                .Where(n => n.UserId == bob.Id)
+                .OrderByDescending(n => n.CreatedAt)
+                .FirstOrDefaultAsync();
+
+            notification.Should().NotBeNull();
+            notification!.Title.Should().Be("Settlement received");
+            notification.Message.Should().Be($"{alice.UserName} settled $25 with you");
+            notification.IsRead.Should().Be((byte)0);
+        });
+
+        var notifRes = await bob.Client.GetAsync("/api/Notification");
+        notifRes.StatusCode.Should().Be(HttpStatusCode.OK);
+        var notifications = await notifRes.Content.ReadFromJsonAsync<List<NotificationDto>>();
+        notifications.Should().Contain(n => n.Title == "Settlement received");
+    }
+
+    [Fact]
     public async Task Endpoints_require_authentication()
     {
         var getRes = await Factory.CreateClient().GetAsync("/api/Settlement");

--- a/docs/ROUTINES_PLAN.md
+++ b/docs/ROUTINES_PLAN.md
@@ -92,7 +92,7 @@ GET  /api/Budget?period=month
 
 - [x] **B1 — Settlement model, repository, endpoints**
 - [x] **B2 — Net balances + per-counterparty balance detail**
-- [ ] **B3 — Settlement notification**
+- [x] **B3 — Settlement notification**
 - [ ] **B4 — Budget model, repository, endpoints**
 - [ ] **B5 — Budget threshold alerts**
 


### PR DESCRIPTION
## What was built

Implements phase **B3 — Settlement notification** from `docs/ROUTINES_PLAN.md`.

- `SettlementRepository.CreateAsync` now calls a new private `NotifyPayeeAsync` helper after the settlement is saved. It:
  - Creates a notification for the **payee** via `ITextractNotification.CreateNotifcation(payeeId, message, "Settlement received", 0)`, resolved from a fresh DI scope (`IServiceProvider.CreateScope()`) — same pattern as `FriendRequestRepository`.
  - Broadcasts the same message over `IHubContext<TextractNotificationHub>.Clients.User(payeeUserName).SendAsync("TextractNotification", message)`.
  - Message format: `"<payerUserName> settled $<amount> with you"`.
  - The whole notification step is wrapped in a `try/catch` that swallows any exception, so a notification failure can never fail the settlement write (per spec).
- No schema/DTO/endpoint changes — this phase only adds the notification side effect to the existing `POST /api/Settlement` flow.

## How it was tested

- `dotnet build` (both `Expense.API.csproj` and the integration test project) — passes with no new warnings.
- Added `SettlementTests.Create_notifies_the_payee`, which:
  - Registers two real users, has one settle with the other.
  - Asserts (via `WithDbAsync`) that the payee received an unread `Notification` row with title `"Settlement received"` and the expected message text.
  - Asserts the same notification is visible through the payee's own `GET /api/Notification` endpoint.
- **Docker/Testcontainers**: I ran the full `SettlementTests` suite locally after starting a Docker daemon in this sandbox, but the sandbox's network policy blocks pulling `testcontainers/ryuk` (and likely the SQL Server/Redis images) from Docker Hub's CDN (403 Forbidden), so I could not execute the suite end-to-end here. GitHub Actions (`.github/workflows/integration-tests.yml`) has unrestricted Docker access and is the gate of record — it will run this suite, including the new test, on this PR.

## Deviations from spec

None. Implementation follows the B3 spec and the `FriendRequestRepository` exemplar (~lines 58–72) as directed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV7t6L74LCFJdFVWYzFpVN)_