### PR TITLE
routine(B4): Budget model, repository, endpoints

### DIFF
--- a/Configurations/RepositoryConfig.cs
+++ b/Configurations/RepositoryConfig.cs
@@ -1,4 +1,5 @@
 ﻿using Expense.API.Repositories.AuthToken;
+using Expense.API.Repositories.Budget;
 using Expense.API.Repositories.Documents;
 using Expense.API.Repositories.Expense;
 using Expense.API.Repositories.ExpenseAnalysis;
@@ -25,6 +26,7 @@ public static class RepositoryConfig
         services.AddScoped<ITextractNotification, TextractNotification>();
         services.AddScoped<IFriendRequestRepository, FriendRequestRespository>();
         services.AddScoped<ISettlementRepository, SettlementRepository>();
+        services.AddScoped<IBudgetRepository, BudgetRepository>();
         services.AddScoped(typeof(QueryBuilder<>));
     }
 }

--- a/Controllers/BudgetController.cs
+++ b/Controllers/BudgetController.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Expense.API.CustomActionFilters;
+using Expense.API.Models.DTO;
+using Expense.API.Repositories.Budget;
+
+namespace Expense.API.Controllers
+{
+    [Route("api/[controller]")]
+    [Authorize]
+    public class BudgetController : Controller
+    {
+        private readonly IBudgetRepository budgetRepository;
+
+        public BudgetController(IBudgetRepository budgetRepository)
+        {
+            this.budgetRepository = budgetRepository;
+        }
+
+        // PUT api/Budget
+        [HttpPut]
+        [ValidateModelAtrribute]
+        public async Task<IActionResult> Put([FromBody] UpsertBudgetDto upsertBudgetDto)
+        {
+            try
+            {
+                var budget = await budgetRepository.UpsertAsync(upsertBudgetDto);
+                return Ok(budget);
+            }
+            catch (Exception e)
+            {
+                return BadRequest(e.Message);
+            }
+        }
+
+        // GET api/Budget?period=month
+        [HttpGet]
+        public async Task<IActionResult> Get([FromQuery] string period = "month")
+        {
+            try
+            {
+                var statuses = await budgetRepository.GetStatusAsync(period);
+                if (statuses == null || !statuses.Any())
+                {
+                    return NotFound("No budgets found for the logged in user");
+                }
+                return Ok(statuses);
+            }
+            catch (Exception e)
+            {
+                return BadRequest($"An error occurred: {e.Message}");
+            }
+        }
+    }
+}

--- a/Data/UserDocumentsDbContext.cs
+++ b/Data/UserDocumentsDbContext.cs
@@ -19,6 +19,7 @@ namespace Expense.API.Data
         public DbSet<Notification> Notification { get; set; }
         public DbSet<FriendRequest> FriendRequests { get; set; }
         public DbSet<Settlement> Settlements { get; set; }
+        public DbSet<Budget> Budgets { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -70,6 +71,20 @@ namespace Expense.API.Data
                 .HasOne(s => s.Payee)
                 .WithMany()
                 .HasForeignKey(s => s.PayeeId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Budget>()
+                .Property(b => b.Category)
+                .HasMaxLength(64);
+
+            modelBuilder.Entity<Budget>()
+                .HasIndex(b => new { b.UserId, b.Category })
+                .IsUnique();
+
+            modelBuilder.Entity<Budget>()
+                .HasOne(b => b.User)
+                .WithMany()
+                .HasForeignKey(b => b.UserId)
                 .OnDelete(DeleteBehavior.Restrict);
         }
     }

--- a/ExpenseAnalyserDbScripts/11-budgets.sql
+++ b/ExpenseAnalyserDbScripts/11-budgets.sql
@@ -1,0 +1,30 @@
+USE ExpenseAnalyserDb;
+GO
+
+-- Budgets: per-user, per-category monthly spending limits.
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE Name = N'Budgets' AND Schema_Id = Schema_Id(N'dbo'))
+BEGIN
+    CREATE TABLE [dbo].[Budgets](
+        [Id] [uniqueidentifier] NOT NULL,
+        [UserId] [uniqueidentifier] NOT NULL,
+        [Category] [nvarchar](64) NOT NULL,
+        [MonthlyLimit] [decimal](18, 2) NOT NULL,
+        [UpdatedAt] [datetime2](7) NOT NULL,
+     CONSTRAINT [PK_Budgets] PRIMARY KEY CLUSTERED
+    (
+        [Id] ASC
+    )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+    ) ON [PRIMARY]
+
+    CREATE UNIQUE NONCLUSTERED INDEX [IX_Budgets_UserId_Category] ON [dbo].[Budgets]
+    (
+        [UserId] ASC,
+        [Category] ASC
+    )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+
+    ALTER TABLE [dbo].[Budgets] WITH CHECK ADD CONSTRAINT [FK_Budgets_Users_UserId] FOREIGN KEY([UserId])
+    REFERENCES [dbo].[Users] ([Id])
+
+    ALTER TABLE [dbo].[Budgets] CHECK CONSTRAINT [FK_Budgets_Users_UserId]
+END
+GO

--- a/Mappings/AutomapperProfiles.cs
+++ b/Mappings/AutomapperProfiles.cs
@@ -37,6 +37,8 @@ namespace Expense.API.Mappings
                 .ForMember(dest => dest.PayeeUserId, opt => opt.MapFrom(src => src.PayeeId))
                 .ForMember(dest => dest.PayeeUserName, opt => opt.MapFrom(src => src.Payee.Username));
 
+            CreateMap<Budget, BudgetDto>();
+
         }
     }
 }

--- a/Migrations/UserDocumentsDb/20260710160900_AddBudgets.Designer.cs
+++ b/Migrations/UserDocumentsDb/20260710160900_AddBudgets.Designer.cs
@@ -4,6 +4,7 @@ using Expense.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Expense.API.Migrations.UserDocumentsDb
 {
     [DbContext(typeof(UserDocumentsDbContext))]
-    partial class UserDocumentsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710160900_AddBudgets")]
+    partial class AddBudgets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/UserDocumentsDb/20260710160900_AddBudgets.cs
+++ b/Migrations/UserDocumentsDb/20260710160900_AddBudgets.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Expense.API.Migrations.UserDocumentsDb
+{
+    /// <inheritdoc />
+    public partial class AddBudgets : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Budgets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Category = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    MonthlyLimit = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Budgets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Budgets_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Budgets_UserId_Category",
+                table: "Budgets",
+                columns: new[] { "UserId", "Category" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Budgets");
+        }
+    }
+}

--- a/Models/DTO/BudgetDto.cs
+++ b/Models/DTO/BudgetDto.cs
@@ -1,0 +1,9 @@
+namespace Expense.API.Models.DTO
+{
+    public class BudgetDto
+    {
+        public Guid Id { get; set; }
+        public string Category { get; set; }
+        public decimal MonthlyLimit { get; set; }
+    }
+}

--- a/Models/DTO/BudgetStatusDto.cs
+++ b/Models/DTO/BudgetStatusDto.cs
@@ -1,0 +1,9 @@
+namespace Expense.API.Models.DTO
+{
+    public class BudgetStatusDto
+    {
+        public string Category { get; set; }
+        public decimal MonthlyLimit { get; set; }
+        public decimal Spent { get; set; }
+    }
+}

--- a/Models/DTO/UpsertBudgetDto.cs
+++ b/Models/DTO/UpsertBudgetDto.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Expense.API.Models.DTO
+{
+    public class UpsertBudgetDto
+    {
+        [Required]
+        public string Category { get; set; }
+
+        [Required]
+        public decimal MonthlyLimit { get; set; }
+    }
+}

--- a/Models/Domain/Budget/Budget.cs
+++ b/Models/Domain/Budget/Budget.cs
@@ -1,0 +1,23 @@
+using System;
+namespace Expense.API.Models.Domain
+{
+	public class Budget
+	{
+		public Budget()
+		{
+		}
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Owner of the budget.
+        /// </summary>
+        public Guid UserId { get; set; }
+        public User User { get; set; }
+
+        public string Category { get; set; }
+
+        public decimal MonthlyLimit { get; set; }
+
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Repositories/Budget/BudgetRepository.cs
+++ b/Repositories/Budget/BudgetRepository.cs
@@ -1,0 +1,120 @@
+using System.Security.Claims;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using Expense.API.Data;
+using Expense.API.Models.Domain;
+using Expense.API.Models.DTO;
+using BudgetModel = Expense.API.Models.Domain.Budget;
+
+namespace Expense.API.Repositories.Budget
+{
+    public class BudgetRepository : IBudgetRepository
+    {
+        private readonly UserDocumentsDbContext userDocumentsDbContext;
+        private readonly IHttpContextAccessor httpContextAccessor;
+        private readonly IMapper mapper;
+
+        public BudgetRepository(UserDocumentsDbContext userDocumentsDbContext, IHttpContextAccessor httpContextAccessor, IMapper mapper)
+        {
+            this.userDocumentsDbContext = userDocumentsDbContext;
+            this.httpContextAccessor = httpContextAccessor;
+            this.mapper = mapper;
+        }
+
+        /// <summary>
+        /// Resolve the current user from the JWT NameIdentifier claim (same lookup as ExpenseRepository).
+        /// </summary>
+        private async Task<User> GetCurrentUserAsync()
+        {
+            var userName = httpContextAccessor.HttpContext?.User?.Claims
+                             .FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
+
+            var user = await userDocumentsDbContext.Users
+                            .FirstOrDefaultAsync(u => u.Username.Equals(userName));
+
+            if (user == null)
+            {
+                throw new Exception("Invalid User");
+            }
+            return user;
+        }
+
+        public async Task<BudgetDto> UpsertAsync(UpsertBudgetDto upsertBudgetDto)
+        {
+            if (upsertBudgetDto.MonthlyLimit <= 0)
+            {
+                throw new Exception("Monthly limit must be greater than zero.");
+            }
+
+            var category = upsertBudgetDto.Category?.Trim();
+            if (string.IsNullOrEmpty(category))
+            {
+                throw new Exception("Category can not be blank.");
+            }
+
+            var user = await GetCurrentUserAsync();
+
+            var budget = await userDocumentsDbContext.Budgets
+                .FirstOrDefaultAsync(b => b.UserId == user.Id && b.Category.ToLower() == category.ToLower());
+
+            if (budget == null)
+            {
+                budget = new BudgetModel
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = user.Id,
+                    User = user,
+                    Category = category,
+                    MonthlyLimit = upsertBudgetDto.MonthlyLimit,
+                    UpdatedAt = DateTime.UtcNow
+                };
+                await userDocumentsDbContext.Budgets.AddAsync(budget);
+            }
+            else
+            {
+                budget.MonthlyLimit = upsertBudgetDto.MonthlyLimit;
+                budget.UpdatedAt = DateTime.UtcNow;
+            }
+
+            await userDocumentsDbContext.SaveChangesAsync();
+
+            return mapper.Map<BudgetDto>(budget);
+        }
+
+        public async Task<List<BudgetStatusDto>> GetStatusAsync(string period)
+        {
+            var user = await GetCurrentUserAsync();
+
+            var budgets = await userDocumentsDbContext.Budgets
+                .Where(b => b.UserId == user.Id)
+                .ToListAsync();
+
+            if (!budgets.Any())
+            {
+                return new List<BudgetStatusDto>();
+            }
+
+            var now = DateTime.UtcNow;
+            var from = new DateTime(now.Year, now.Month, 1);
+
+            var spentRaw = await userDocumentsDbContext.Expenses
+                .Where(e => e.CreatedById == user.Id && e.CreatedAt >= from && e.CreatedAt <= now)
+                .GroupBy(e => e.Category)
+                .Select(g => new { g.Key, Amount = g.Sum(e => e.Amount) })
+                .ToListAsync();
+
+            var spentByCategory = spentRaw
+                .GroupBy(c => (c.Key ?? "Other").Trim().ToLowerInvariant())
+                .ToDictionary(g => g.Key, g => g.Sum(c => c.Amount));
+
+            return budgets
+                .Select(b => new BudgetStatusDto
+                {
+                    Category = b.Category,
+                    MonthlyLimit = b.MonthlyLimit,
+                    Spent = spentByCategory.TryGetValue(b.Category.Trim().ToLowerInvariant(), out var spent) ? spent : 0m
+                })
+                .ToList();
+        }
+    }
+}

--- a/Repositories/Budget/IBudgetRepository.cs
+++ b/Repositories/Budget/IBudgetRepository.cs
@@ -1,0 +1,17 @@
+using Expense.API.Models.DTO;
+
+namespace Expense.API.Repositories.Budget
+{
+    public interface IBudgetRepository
+    {
+        /// <summary>
+        /// Insert or update the logged in user's budget for the given category (case-insensitive match).
+        /// </summary>
+        Task<BudgetDto> UpsertAsync(UpsertBudgetDto upsertBudgetDto);
+
+        /// <summary>
+        /// The logged in user's budgets joined with their spend for the given period.
+        /// </summary>
+        Task<List<BudgetStatusDto>> GetStatusAsync(string period);
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/BudgetTests.cs
+++ b/Tests/Expense.API.IntegrationTests/BudgetTests.cs
@@ -78,17 +78,16 @@ public class BudgetTests : IntegrationTestBase
     {
         var alice = await RegisterAndLoginAsync("budgetstatus");
         var now = DateTime.UtcNow;
-        var thisMonth = new DateTime(now.Year, now.Month, 15, 0, 0, 0, DateTimeKind.Utc);
-        var lastMonth = thisMonth.AddMonths(-1);
+        var lastMonth = now.AddMonths(-1);
 
         await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto { Category = "Groceries", MonthlyLimit = 300m });
         await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto { Category = "Other", MonthlyLimit = 50m });
 
         await WithDbAsync(async db =>
         {
-            SeedData.AddExpense(db, alice.Id, "Weekly shop", 120m, "Groceries", thisMonth);
-            SeedData.AddExpense(db, alice.Id, "More shopping", 40m, "Groceries", thisMonth);
-            SeedData.AddExpense(db, alice.Id, "Misc", 25m, null, thisMonth);
+            SeedData.AddExpense(db, alice.Id, "Weekly shop", 120m, "Groceries", now);
+            SeedData.AddExpense(db, alice.Id, "More shopping", 40m, "Groceries", now);
+            SeedData.AddExpense(db, alice.Id, "Misc", 25m, null, now);
             SeedData.AddExpense(db, alice.Id, "Prior month shop", 999m, "Groceries", lastMonth);
             await db.SaveChangesAsync();
         });

--- a/Tests/Expense.API.IntegrationTests/BudgetTests.cs
+++ b/Tests/Expense.API.IntegrationTests/BudgetTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Net.Http.Json;
+using Expense.API.IntegrationTests.Infrastructure;
+using Expense.API.Models.DTO;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+public class BudgetTests : IntegrationTestBase
+{
+    public BudgetTests(CustomWebAppFactory factory) : base(factory) { }
+
+    [Fact]
+    public async Task Put_creates_then_updates_the_same_row()
+    {
+        var alice = await RegisterAndLoginAsync("budgetalice");
+
+        var createRes = await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto
+        {
+            Category = "Groceries",
+            MonthlyLimit = 200m
+        });
+        createRes.StatusCode.Should().Be(HttpStatusCode.OK);
+        var created = await createRes.Content.ReadFromJsonAsync<BudgetDto>();
+        created!.Category.Should().Be("Groceries");
+        created.MonthlyLimit.Should().Be(200m);
+
+        var updateRes = await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto
+        {
+            Category = "Groceries",
+            MonthlyLimit = 300m
+        });
+        updateRes.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await updateRes.Content.ReadFromJsonAsync<BudgetDto>();
+        updated!.Id.Should().Be(created.Id);
+        updated.MonthlyLimit.Should().Be(300m);
+
+        await WithDbAsync(async db =>
+        {
+            var rows = await db.Budgets.Where(b => b.UserId == alice.Id).ToListAsync();
+            rows.Should().HaveCount(1);
+            rows[0].MonthlyLimit.Should().Be(300m);
+        });
+    }
+
+    [Fact]
+    public async Task Put_rejects_non_positive_limit()
+    {
+        var alice = await RegisterAndLoginAsync("budgetzero");
+
+        var res = await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto
+        {
+            Category = "Groceries",
+            MonthlyLimit = 0m
+        });
+
+        res.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Put_rejects_blank_category()
+    {
+        var alice = await RegisterAndLoginAsync("budgetblank");
+
+        var res = await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto
+        {
+            Category = "   ",
+            MonthlyLimit = 100m
+        });
+
+        res.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Get_returns_status_with_exact_spend_including_other_bucket()
+    {
+        var alice = await RegisterAndLoginAsync("budgetstatus");
+        var now = DateTime.UtcNow;
+        var thisMonth = new DateTime(now.Year, now.Month, 15, 0, 0, 0, DateTimeKind.Utc);
+        var lastMonth = thisMonth.AddMonths(-1);
+
+        await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto { Category = "Groceries", MonthlyLimit = 300m });
+        await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto { Category = "Other", MonthlyLimit = 50m });
+
+        await WithDbAsync(async db =>
+        {
+            SeedData.AddExpense(db, alice.Id, "Weekly shop", 120m, "Groceries", thisMonth);
+            SeedData.AddExpense(db, alice.Id, "More shopping", 40m, "Groceries", thisMonth);
+            SeedData.AddExpense(db, alice.Id, "Misc", 25m, null, thisMonth);
+            SeedData.AddExpense(db, alice.Id, "Prior month shop", 999m, "Groceries", lastMonth);
+            await db.SaveChangesAsync();
+        });
+
+        var res = await alice.Client.GetAsync("/api/Budget?period=month");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var statuses = await res.Content.ReadFromJsonAsync<List<BudgetStatusDto>>();
+
+        statuses.Should().HaveCount(2);
+        statuses.Should().ContainSingle(s => s.Category == "Groceries" && s.MonthlyLimit == 300m && s.Spent == 160m);
+        statuses.Should().ContainSingle(s => s.Category == "Other" && s.MonthlyLimit == 50m && s.Spent == 25m);
+    }
+
+    [Fact]
+    public async Task Get_returns_not_found_when_caller_has_no_budgets()
+    {
+        var lonely = await RegisterAndLoginAsync("budgetlonely");
+
+        var res = await lonely.Client.GetAsync("/api/Budget");
+
+        res.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Endpoints_require_authentication()
+    {
+        var getRes = await Factory.CreateClient().GetAsync("/api/Budget");
+        getRes.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+        var putRes = await Factory.CreateClient().PutAsJsonAsync("/api/Budget", new UpsertBudgetDto
+        {
+            Category = "Groceries",
+            MonthlyLimit = 100m
+        });
+        putRes.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/docs/ROUTINES_PLAN.md
+++ b/docs/ROUTINES_PLAN.md
@@ -21,11 +21,26 @@ against them without waiting for these phases to merge.
    one phase.
 5. Quality gates:
    - `dotnet build` must pass with no new warnings-as-errors.
-   - `dotnet test Tests/Expense.API.IntegrationTests` — the suite spins up SQL Server + Redis
-     via Testcontainers and needs a Docker daemon. If Docker is unavailable in the sandbox,
-     note this in the PR body; GitHub Actions (`.github/workflows/integration-tests.yml`)
-     runs the full suite on every push/PR and is the gate of record.
-   - New/changed behaviour **must** have integration tests either way.
+   - `dotnet test Tests/Expense.API.IntegrationTests` — **always attempt this**, it's not
+     optional-by-default. The suite spins up SQL Server + Redis via Testcontainers and needs
+     a Docker daemon plus the ability to pull `mcr.microsoft.com/mssql/server`,
+     `redis`, and `testcontainers/ryuk` images. Try: is a daemon reachable (`docker info`),
+     and can those images actually be pulled (`docker pull testcontainers/ryuk:0.6.0`)? Only
+     if that pull is genuinely blocked (sandbox network policy denies the registry) skip
+     running the suite — and say so explicitly in the PR body, including the exact error.
+     Otherwise run the full suite (not just the new phase's test file) before opening the PR
+     and paste the pass/fail summary into the PR body. GitHub Actions
+     (`.github/workflows/integration-tests.yml`) runs the full suite on every push/PR
+     regardless and is the gate of record — but a runner that could have caught a failing
+     test locally and didn't is a bug in the run, not just bad luck.
+   - New/changed behaviour **must** have integration tests, written in the same run as the
+     code they cover — not a follow-up. Follow the date/time conventions already used in
+     `DashboardTests.cs` and friends: seed "current period" fixtures with `DateTime.UtcNow`
+     captured once per test (not a hand-picked day-of-month like the 15th), since a fixture
+     dated later in the current month than the day the suite actually runs on silently drops
+     out of any `CreatedAt <= now` window and fails only on some days. Seed "prior period"
+     fixtures via `.AddMonths(-1)`/`.AddDays(-N)` off that same `now`, not a second hand-picked
+     constant.
 6. In the same branch, tick this phase's checkbox below (`- [ ]` → `- [x]`).
 7. Commit (conventional commits, e.g. `feat(settlement): add model, repository and endpoints (phase B1)`),
    push, and open a PR titled `routine(B<id>): <phase title>`. PR body: what was built, how it

--- a/docs/ROUTINES_PLAN.md
+++ b/docs/ROUTINES_PLAN.md
@@ -93,7 +93,7 @@ GET  /api/Budget?period=month
 - [x] **B1 — Settlement model, repository, endpoints**
 - [x] **B2 — Net balances + per-counterparty balance detail**
 - [x] **B3 — Settlement notification**
-- [ ] **B4 — Budget model, repository, endpoints**
+- [x] **B4 — Budget model, repository, endpoints**
 - [ ] **B5 — Budget threshold alerts**
 
 ---


### PR DESCRIPTION
Implements phase **B4** from `docs/ROUTINES_PLAN.md`: per-user, per-category monthly budgets.

## What was built

- `Models/Domain/Budget/Budget.cs`: `Id`, `UserId` + `User` nav, `Category` (max 64), `MonthlyLimit`, `UpdatedAt`. `DbSet<Budget> Budgets` added to `UserDocumentsDbContext` with a unique `(UserId, Category)` index and `DeleteBehavior.Restrict` on the `User` FK, matching the `Settlement` configuration style.
- SQL script `ExpenseAnalyserDbScripts/11-budgets.sql` (idempotent, same style as `10-settlements.sql`) plus EF migration `20260710160900_AddBudgets` — the generated migration matches the SQL script's table/index/FK shape exactly.
- DTOs `BudgetDto`, `UpsertBudgetDto`, `BudgetStatusDto` per the fixed API contract; `Budget → BudgetDto` AutoMapper map added.
- `Repositories/Budget/IBudgetRepository.cs` + `BudgetRepository.cs`:
  - `UpsertAsync`: validates `MonthlyLimit > 0` and non-blank category, does a case-insensitive lookup by `(UserId, Category)` to update-in-place or insert.
  - `GetStatusAsync`: joins the caller's budgets with their current-calendar-month expense totals per category, reusing `GetDashboardSummaryAsync`'s `null Category → "Other"` semantics (merged case-insensitively so a literal `"Other"` budget also catches uncategorised spend).
  - Registered in `RepositoryConfig`.
- `Controllers/BudgetController.cs`: `PUT /api/Budget` → 200 `BudgetDto` (400 on validation failure); `GET /api/Budget?period=month` → `BudgetStatusDto[]` or 404 when the caller has no budgets. Mirrors `SettlementController` conventions (`ValidateModelAtrribute`, try/catch → `BadRequest`).

## Testing

- `Tests/Expense.API.IntegrationTests/BudgetTests.cs`: upsert creates then updates the same row (asserted via DB + response), validation 400s (non-positive limit, blank category), exact `spent` math via `SeedData.AddExpense` (categorised + uncategorised expenses, "Other" bucket), prior-calendar-month expenses excluded, empty → 404, and auth is required on both endpoints.
- `dotnet build` passes with no new warnings/errors (only the pre-existing warnings already present on `main`).
- `dotnet test Tests/Expense.API.IntegrationTests` — **could not run in this sandbox**: the Docker daemon itself is available, but `docker pull testcontainers/ryuk:...` is blocked by the sandbox's network egress policy (403 on the image registry CDN), so Testcontainers can't spin up SQL Server/Redis here. GitHub Actions (`.github/workflows/integration-tests.yml`) is the gate of record and will run the full suite including the new `BudgetTests.cs` on this PR.

## Deviations from spec

None. Implementation follows the B4 spec and the `Settlement` (B1) pattern files closely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FN1REtgMfaHrKnF2vReM3i)_