### PR TITLE
routine(B5): Budget threshold alerts

### DIFF
--- a/Repositories/Expense/ExpenseRepository.cs
+++ b/Repositories/Expense/ExpenseRepository.cs
@@ -1,11 +1,14 @@
 ﻿using System.Globalization;
 using System.Security.Claims;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Expense.API.Data;
 using Expense.API.Models.Domain;
 using ExpenseModel = Expense.API.Models.Domain.Expense;
+using BudgetModel = Expense.API.Models.Domain.Budget;
 using System;
 using Expense.API.Models.DTO;
+using Expense.API.Repositories.Notifications;
 using Expense.API.Repositories.QueryBuilder;
 
 namespace Expense.API.Repositories.Expense
@@ -14,11 +17,16 @@ namespace Expense.API.Repositories.Expense
 	{
         private readonly UserDocumentsDbContext userDocumentsDbContext;
         private readonly IHttpContextAccessor httpContextAccessor;
-        
-        public ExpenseRepository(UserDocumentsDbContext userDocumentsDbContext, IHttpContextAccessor httpContextAccessor)
+        private readonly IServiceProvider serviceProvider;
+        private readonly IHubContext<TextractNotificationHub> textractNotification;
+
+        public ExpenseRepository(UserDocumentsDbContext userDocumentsDbContext, IHttpContextAccessor httpContextAccessor,
+            IServiceProvider serviceProvider, IHubContext<TextractNotificationHub> textractNotification)
 		{
             this.userDocumentsDbContext = userDocumentsDbContext;
             this.httpContextAccessor = httpContextAccessor;
+            this.serviceProvider = serviceProvider;
+            this.textractNotification = textractNotification;
 		}
 
         public async Task<ExpenseModel> CreateExpenseAsync(ExpenseModel expense)
@@ -37,6 +45,7 @@ namespace Expense.API.Repositories.Expense
                 expense.CreatedById = user.Id;
                 await userDocumentsDbContext.Expenses.AddAsync(expense);
                 await userDocumentsDbContext.SaveChangesAsync();
+                await CheckBudgetThresholdAsync(expense);
             }
             else
             {
@@ -312,6 +321,7 @@ namespace Expense.API.Repositories.Expense
                 expense.Description = updateExpenseDto.Description;
                 expense.Category = updateExpenseDto.Category;
                 await userDocumentsDbContext.SaveChangesAsync();
+                await CheckBudgetThresholdAsync(expense);
                 return expense;
             }
             throw new Exception("Update Failed, Expense Not found");
@@ -574,6 +584,90 @@ namespace Expense.API.Repositories.Expense
                 Direction = net > 0 ? "owedToYou" : net < 0 ? "youOwe" : "settled",
                 Entries = entries
             };
+        }
+
+        // ----- Budget threshold alerts -----
+
+        private static string NormalizeCategory(string? category)
+        {
+            var trimmed = category?.Trim();
+            return string.IsNullOrEmpty(trimmed) ? "Other" : trimmed;
+        }
+
+        /// <summary>
+        /// Sum of the user's current-calendar-month expenses in the given category (same "Other"
+        /// bucket semantics as GetDashboardSummaryAsync/BudgetRepository), excluding one expense.
+        /// </summary>
+        private async Task<decimal> GetCurrentMonthCategorySpentAsync(Guid userId, string normalizedCategory, Guid excludeExpenseId)
+        {
+            var now = DateTime.UtcNow;
+            var from = new DateTime(now.Year, now.Month, 1);
+
+            var expenses = await userDocumentsDbContext.Expenses
+                .Where(e => e.CreatedById == userId && e.CreatedAt >= from && e.CreatedAt <= now && e.Id != excludeExpenseId)
+                .Select(e => new { e.Category, e.Amount })
+                .ToListAsync();
+
+            return expenses
+                .Where(e => NormalizeCategory(e.Category).Equals(normalizedCategory, StringComparison.OrdinalIgnoreCase))
+                .Sum(e => e.Amount);
+        }
+
+        /// <summary>
+        /// After an expense create/update, alert the owner once per budget/threshold/month when the
+        /// expense's category utilization crosses 80% or 100%. A notification failure must not fail
+        /// the expense write.
+        /// </summary>
+        private async Task CheckBudgetThresholdAsync(ExpenseModel expense)
+        {
+            try
+            {
+                var normalizedCategory = NormalizeCategory(expense.Category);
+
+                var budget = await userDocumentsDbContext.Budgets.FirstOrDefaultAsync(
+                    b => b.UserId == expense.CreatedById && b.Category.ToLower() == normalizedCategory.ToLower());
+
+                if (budget == null || budget.MonthlyLimit <= 0)
+                {
+                    return;
+                }
+
+                var spentExcludingThis = await GetCurrentMonthCategorySpentAsync(expense.CreatedById, normalizedCategory, expense.Id);
+                var spentIncludingThis = spentExcludingThis + expense.Amount;
+
+                var beforePct = (double)(spentExcludingThis / budget.MonthlyLimit) * 100.0;
+                var afterPct = (double)(spentIncludingThis / budget.MonthlyLimit) * 100.0;
+
+                foreach (var threshold in new[] { 80.0, 100.0 })
+                {
+                    if (beforePct < threshold && afterPct >= threshold)
+                    {
+                        await NotifyBudgetThresholdAsync(expense.CreatedById, budget, afterPct);
+                    }
+                }
+            }
+            catch
+            {
+                // Swallow: a notification failure must not fail the expense write.
+            }
+        }
+
+        private async Task NotifyBudgetThresholdAsync(Guid userId, BudgetModel budget, double afterPct)
+        {
+            var pctRounded = (int)Math.Round(afterPct, MidpointRounding.AwayFromZero);
+            var message = $"You've used {pctRounded}% of your ${budget.MonthlyLimit:0.##} {budget.Category} budget this month";
+
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var textractNotificationDb = scope.ServiceProvider.GetRequiredService<ITextractNotification>();
+                await textractNotificationDb.CreateNotifcation(userId, message, "Budget alert", 0);
+            }
+
+            var user = await userDocumentsDbContext.Users.FirstOrDefaultAsync(u => u.Id == userId);
+            if (user != null)
+            {
+                await textractNotification.Clients.User(user.Username).SendAsync("TextractNotification", message);
+            }
         }
     }
 }

--- a/Tests/Expense.API.IntegrationTests/BudgetAlertTests.cs
+++ b/Tests/Expense.API.IntegrationTests/BudgetAlertTests.cs
@@ -1,0 +1,169 @@
+using System.Net;
+using System.Net.Http.Json;
+using Expense.API.IntegrationTests.Infrastructure;
+using Expense.API.Models.DTO;
+using FluentAssertions;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+/// <summary>
+/// Amount/category aren't settable via the public create endpoint (POST /api/Expense hardcodes
+/// amount=0 and leaves category null), so these push a category's current-month spend across a
+/// budget threshold via PUT /api/Expense/{id} category reassignment - the only lever the existing
+/// HTTP surface offers to move a priced, seeded expense into a budgeted category. The same
+/// ExpenseRepository hook fires identically from CreateExpenseAsync.
+/// </summary>
+public class BudgetAlertTests : IntegrationTestBase
+{
+    public BudgetAlertTests(CustomWebAppFactory factory) : base(factory) { }
+
+    private async Task<List<NotificationDto>> GetBudgetAlertsAsync(HttpClient client)
+    {
+        var res = await client.GetAsync("/api/Notification");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var notifications = await res.Content.ReadFromJsonAsync<List<NotificationDto>>();
+        return notifications!.Where(n => n.Title == "Budget alert").ToList();
+    }
+
+    [Fact]
+    public async Task Category_reassignment_crossing_80_percent_yields_exactly_one_alert()
+    {
+        var alice = await RegisterAndLoginAsync("budgetalert80");
+        var now = DateTime.UtcNow;
+
+        await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto { Category = "Groceries", MonthlyLimit = 300m });
+
+        var movedExpenseId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            SeedData.AddExpense(db, alice.Id, "Groceries 1", 120m, "Groceries", now);
+            SeedData.AddExpense(db, alice.Id, "Groceries 2", 90m, "Groceries", now); // 210 = 70%
+            var moved = SeedData.AddExpense(db, alice.Id, "Snack run", 30m, "Snacks", now); // -> 240 = 80% once moved
+            await db.SaveChangesAsync();
+            movedExpenseId = moved.Id;
+        });
+
+        var res = await alice.Client.PutAsJsonAsync($"/api/Expense/{movedExpenseId}",
+            new UpdateExpenseDto(movedExpenseId.ToString(), "Snack run", "Snack run description", "Groceries"));
+        res.StatusCode.Should().Be(HttpStatusCode.OK, await res.Content.ReadAsStringAsync());
+
+        var alerts = await GetBudgetAlertsAsync(alice.Client);
+        alerts.Should().ContainSingle();
+        alerts[0].Message.Should().Be("You've used 80% of your $300 Groceries budget this month");
+    }
+
+    [Fact]
+    public async Task Category_reassignment_staying_below_80_percent_yields_no_alert()
+    {
+        var alice = await RegisterAndLoginAsync("budgetalertlow");
+        var now = DateTime.UtcNow;
+
+        await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto { Category = "Groceries", MonthlyLimit = 300m });
+
+        var movedExpenseId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            SeedData.AddExpense(db, alice.Id, "Groceries 1", 50m, "Groceries", now); // 50 = 16.7%
+            var moved = SeedData.AddExpense(db, alice.Id, "Snack run", 20m, "Snacks", now); // -> 70 = 23.3% once moved
+            await db.SaveChangesAsync();
+            movedExpenseId = moved.Id;
+        });
+
+        var res = await alice.Client.PutAsJsonAsync($"/api/Expense/{movedExpenseId}",
+            new UpdateExpenseDto(movedExpenseId.ToString(), "Snack run", "Snack run description", "Groceries"));
+        res.StatusCode.Should().Be(HttpStatusCode.OK, await res.Content.ReadAsStringAsync());
+
+        (await GetBudgetAlertsAsync(alice.Client)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Sequential_reassignments_cross_80_then_100_with_exactly_one_alert_each()
+    {
+        var alice = await RegisterAndLoginAsync("budgetalertseq");
+        var now = DateTime.UtcNow;
+
+        await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto { Category = "Groceries", MonthlyLimit = 300m });
+
+        var firstMoveId = Guid.Empty;
+        var secondMoveId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            SeedData.AddExpense(db, alice.Id, "Groceries base", 210m, "Groceries", now); // 70%
+            var first = SeedData.AddExpense(db, alice.Id, "Snack A", 30m, "Snacks", now);   // -> 240 = 80% once moved
+            var second = SeedData.AddExpense(db, alice.Id, "Snack B", 65m, "Snacks", now);  // -> 305 = 101.67% once moved
+            await db.SaveChangesAsync();
+            firstMoveId = first.Id;
+            secondMoveId = second.Id;
+        });
+
+        // 70% -> 80%: crosses the 80% threshold only.
+        var firstRes = await alice.Client.PutAsJsonAsync($"/api/Expense/{firstMoveId}",
+            new UpdateExpenseDto(firstMoveId.ToString(), "Snack A", "Snack A description", "Groceries"));
+        firstRes.StatusCode.Should().Be(HttpStatusCode.OK, await firstRes.Content.ReadAsStringAsync());
+
+        var alertsAfterFirst = await GetBudgetAlertsAsync(alice.Client);
+        alertsAfterFirst.Should().ContainSingle();
+        alertsAfterFirst[0].Message.Should().Be("You've used 80% of your $300 Groceries budget this month");
+
+        // 80% -> ~101.67%: crosses the 100% threshold only, no repeat 80% alert.
+        var secondRes = await alice.Client.PutAsJsonAsync($"/api/Expense/{secondMoveId}",
+            new UpdateExpenseDto(secondMoveId.ToString(), "Snack B", "Snack B description", "Groceries"));
+        secondRes.StatusCode.Should().Be(HttpStatusCode.OK, await secondRes.Content.ReadAsStringAsync());
+
+        var alertsAfterSecond = await GetBudgetAlertsAsync(alice.Client);
+        alertsAfterSecond.Should().HaveCount(2);
+        alertsAfterSecond.Should().ContainSingle(a => a.Message == "You've used 80% of your $300 Groceries budget this month");
+        alertsAfterSecond.Should().ContainSingle(a => a.Message == "You've used 102% of your $300 Groceries budget this month");
+    }
+
+    [Fact]
+    public async Task Reassignment_within_80_to_99_percent_after_already_crossing_80_yields_no_new_alert()
+    {
+        var alice = await RegisterAndLoginAsync("budgetalertmid");
+        var now = DateTime.UtcNow;
+
+        await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto { Category = "Groceries", MonthlyLimit = 300m });
+
+        var movedExpenseId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            SeedData.AddExpense(db, alice.Id, "Groceries base", 250m, "Groceries", now); // already 83.3%
+            var moved = SeedData.AddExpense(db, alice.Id, "Snack", 10m, "Snacks", now);  // -> 260 = 86.7% once moved, still <100%
+            await db.SaveChangesAsync();
+            movedExpenseId = moved.Id;
+        });
+
+        var res = await alice.Client.PutAsJsonAsync($"/api/Expense/{movedExpenseId}",
+            new UpdateExpenseDto(movedExpenseId.ToString(), "Snack", "Snack description", "Groceries"));
+        res.StatusCode.Should().Be(HttpStatusCode.OK, await res.Content.ReadAsStringAsync());
+
+        (await GetBudgetAlertsAsync(alice.Client)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Uncategorised_expenses_count_against_other_budget()
+    {
+        var alice = await RegisterAndLoginAsync("budgetalertother");
+        var now = DateTime.UtcNow;
+
+        await alice.Client.PutAsJsonAsync("/api/Budget", new UpsertBudgetDto { Category = "Other", MonthlyLimit = 100m });
+
+        var movedExpenseId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            SeedData.AddExpense(db, alice.Id, "Misc 1", 60m, null, now); // uncategorised -> Other bucket, 60%
+            var moved = SeedData.AddExpense(db, alice.Id, "Misc 2", 25m, "Temp", now); // -> 85% once moved to uncategorised
+            await db.SaveChangesAsync();
+            movedExpenseId = moved.Id;
+        });
+
+        var res = await alice.Client.PutAsJsonAsync($"/api/Expense/{movedExpenseId}",
+            new UpdateExpenseDto(movedExpenseId.ToString(), "Misc 2", "Misc 2 description", null));
+        res.StatusCode.Should().Be(HttpStatusCode.OK, await res.Content.ReadAsStringAsync());
+
+        var alerts = await GetBudgetAlertsAsync(alice.Client);
+        alerts.Should().ContainSingle();
+        alerts[0].Message.Should().Be("You've used 85% of your $100 Other budget this month");
+    }
+}

--- a/docs/ROUTINES_PLAN.md
+++ b/docs/ROUTINES_PLAN.md
@@ -120,7 +120,7 @@ POST /api/Expense/{id}/addUser?userId=   (existing endpoint; after B7 friend-gat
 - [x] **B2 — Net balances + per-counterparty balance detail**
 - [x] **B3 — Settlement notification**
 - [x] **B4 — Budget model, repository, endpoints**
-- [ ] **B5 — Budget threshold alerts**
+- [x] **B5 — Budget threshold alerts**
 - [ ] **B6 — Expose `userId` on `GET /api/Friends/getFriends`**
 - [ ] **B7 — Require friendship before adding a user to an expense split**
 


### PR DESCRIPTION
## What

Implements phase **B5 — Budget threshold alerts** from `docs/ROUTINES_PLAN.md`.

After an expense is created or updated (`ExpenseRepository.CreateExpenseAsync` /
`UpdateExpenseAsync`), if the expense's category has a budget for the current calendar month,
compute that category's spend utilization before/after the change. When utilization **crosses**
80% or 100% (strictly `before < threshold && after >= threshold`), the expense owner gets a
notification (title `"Budget alert"`, e.g. `"You've used 82% of your $300 Groceries budget this
month"`) via `ITextractNotification.CreateNotifcation` + the SignalR hub broadcast — same
mechanics as B3's settlement notification (`SettlementRepository.NotifyPayeeAsync`). A
notification failure can't fail the expense write (whole check wrapped in try/catch).

Crossing-only semantics (re-derived from current before/after totals on every call, no new
table) mean a budget/threshold/month combination alerts at most once: once utilization is already
≥80%, further spend in the 80–99% range doesn't refire the 80% alert; it can still separately
cross and fire the 100% alert. Uncategorised expenses (`Category == null`) are bucketed into
`"Other"`, matching `GetDashboardSummaryAsync`/`BudgetRepository` semantics.

### Files
- `Repositories/Expense/ExpenseRepository.cs`: added `IServiceProvider` +
  `IHubContext<TextractNotificationHub>` to the constructor (mirrors `SettlementRepository`);
  added `CheckBudgetThresholdAsync`, `NotifyBudgetThresholdAsync`,
  `GetCurrentMonthCategorySpentAsync`, `NormalizeCategory` helpers; hooked the check into
  `CreateExpenseAsync` and `UpdateExpenseAsync` after `SaveChangesAsync`.
- `Tests/Expense.API.IntegrationTests/BudgetAlertTests.cs` (new).
- `docs/ROUTINES_PLAN.md`: ticked B5.

## Spec deviation

The public API surface doesn't currently let a caller set an expense's `Amount` on create or
update: `POST /api/Expense` hardcodes `Amount = 0` and only takes `title`/`description`, and
`PUT /api/Expense/{id}` only updates `Title`/`Description`/`Category`. So in practice, today,
only a **category reassignment** on an already-priced expense (seeded directly, e.g. via
Textract or test fixtures) can move a nonzero amount across a category bucket and cross a
budget threshold through the public HTTP surface. `BudgetAlertTests.cs` therefore exercises the
crossing logic exclusively via `PUT /api/Expense/{id}` category reassignment on seeded expenses,
per the doc comment at the top of the test file. The `CheckBudgetThresholdAsync` hook is wired
identically into `CreateExpenseAsync`, so it will fire correctly the moment any future flow
(e.g. the Textract receipt pipeline) supplies a categorized, priced expense at creation time.

## Testing

- `dotnet build` (via the .NET 8 SDK, `net7.0` roll-forward for compilation): **0 errors**, 107
  pre-existing nullable-reference warnings (none new/related to this change).
- `dotnet test Tests/Expense.API.IntegrationTests`: **could not run in this environment**, for
  two independent reasons, both confirmed and neither bypassable without violating the sandbox's
  network policy:
  1. No `net7.0` shared runtime is installed or installable here — only `.NET 8` SDK/runtime
     could be installed (Ubuntu 24.04's `dotnet-sdk-7.0` package no longer exists post-EOL, and
     Microsoft's `dotnet-install.sh`/`builds.dotnet.microsoft.com` is blocked by the environment's
     proxy policy). Running the test host fails with: `You must install or update .NET to run
     this application. ... Framework: 'Microsoft.NETCore.App', version '7.0.0' (x64)`.
  2. Separately, after starting the (not-running-by-default) Docker daemon manually, `docker pull
     mcr.microsoft.com/mssql/server` succeeds directly, but `docker pull redis` and `docker pull
     testcontainers/ryuk:0.6.0` (both Docker-Hub-hosted) both fail with the same error, confirming
     the registry pull is genuinely blocked for this environment:
     `Get "https://production.cloudfront.docker.com/registry-v2/.../data?...": Forbidden`.

  GitHub Actions (`.github/workflows/integration-tests.yml`) runs the full suite on this PR
  regardless and is the gate of record — please check that it's green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7yoTrn3ZDj7QNXzMrwt4C)_