### PR TITLE
routine(B6): Expose userId on GET /api/Friends/getFriends

### DIFF
--- a/Models/DTO/FriendsListDto.cs
+++ b/Models/DTO/FriendsListDto.cs
@@ -6,6 +6,7 @@ namespace Expense.API.Models.DTO
 
     public class FriendsListDto
 	{
+        public Guid UserId { get; set; }
         public required string Username { get; set; }
         public string Date => AcceptedAt.ToShortDateString();
         [JsonIgnore]

--- a/Repositories/FriendRequest/FriendRequestRepository.cs
+++ b/Repositories/FriendRequest/FriendRequestRepository.cs
@@ -145,6 +145,7 @@ namespace Expense.API.Repositories.FriendRequest
                     .Select(friend =>
                         new FriendsListDto
                         {
+                            UserId = friend.SentByUserId == user.Id ? friend.SentToUserId : friend.SentByUserId,
                             Username = friend.SentByUserId == user.Id ? friend.SentToUser.Username : friend.SentByUser.Username,
                             AcceptedAt = (DateTime)friend.AcceptedAt,
                             SharedExpenses = new List<ExpenseDto>()

--- a/Tests/Expense.API.IntegrationTests/FriendsTests.cs
+++ b/Tests/Expense.API.IntegrationTests/FriendsTests.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using System.Net.Http.Json;
+using Expense.API.IntegrationTests.Infrastructure;
+using Expense.API.Models.Domain;
+using Expense.API.Models.DTO;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+public class FriendsTests : IntegrationTestBase
+{
+    public FriendsTests(CustomWebAppFactory factory) : base(factory) { }
+
+    private async Task BefriendAsync(TestUser sender, TestUser recipient)
+    {
+        var sendRequest = await sender.Client.PostAsJsonAsync("/api/Friends/sendRequest", new UserDto
+        {
+            Id = recipient.Id,
+            Username = recipient.UserName
+        });
+        sendRequest.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        Guid notificationId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var friendRequest = await db.FriendRequests.FirstOrDefaultAsync(
+                fr => fr.SentByUserId == sender.Id && fr.SentToUserId == recipient.Id);
+            friendRequest.Should().NotBeNull();
+            notificationId = friendRequest!.NotificationId;
+        });
+
+        var acceptRequest = await recipient.Client.PostAsJsonAsync("/api/Friends/acceptRequest", notificationId.ToString());
+        acceptRequest.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task GetFriends_returns_the_counterparty_userId_when_caller_sent_the_request()
+    {
+        var sender = await RegisterAndLoginAsync("sender");
+        var recipient = await RegisterAndLoginAsync("recipient");
+        await BefriendAsync(sender, recipient);
+
+        var res = await sender.Client.GetAsync("/api/Friends/getFriends");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var friends = await res.Content.ReadFromJsonAsync<List<FriendsListDto>>();
+
+        friends.Should().ContainSingle(f => f.Username == recipient.UserName)
+            .Which.UserId.Should().Be(recipient.Id);
+    }
+
+    [Fact]
+    public async Task GetFriends_returns_the_counterparty_userId_when_caller_received_the_request()
+    {
+        var sender = await RegisterAndLoginAsync("sender");
+        var recipient = await RegisterAndLoginAsync("recipient");
+        await BefriendAsync(sender, recipient);
+
+        var res = await recipient.Client.GetAsync("/api/Friends/getFriends");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var friends = await res.Content.ReadFromJsonAsync<List<FriendsListDto>>();
+
+        friends.Should().ContainSingle(f => f.Username == sender.UserName)
+            .Which.UserId.Should().Be(sender.Id);
+    }
+}

--- a/docs/ROUTINES_PLAN.md
+++ b/docs/ROUTINES_PLAN.md
@@ -121,7 +121,7 @@ POST /api/Expense/{id}/addUser?userId=   (existing endpoint; after B7 friend-gat
 - [x] **B3 — Settlement notification**
 - [x] **B4 — Budget model, repository, endpoints**
 - [x] **B5 — Budget threshold alerts**
-- [ ] **B6 — Expose `userId` on `GET /api/Friends/getFriends`**
+- [x] **B6 — Expose `userId` on `GET /api/Friends/getFriends`**
 - [ ] **B7 — Require friendship before adding a user to an expense split**
 
 ---


### PR DESCRIPTION
## What

Implements phase **B6** from `docs/ROUTINES_PLAN.md`: exposes the counterparty's `userId` on `GET /api/Friends/getFriends`, so the frontend can link a friend row to `/balances/{userId}` (from phase B2) even for a friend who is fully settled up and no longer appears in the dashboard balances panel.

- `Models/DTO/FriendsListDto.cs`: added `public Guid UserId { get; set; }`.
- `Repositories/FriendRequest/FriendRequestRepository.cs`, `GetFriends()`: set `UserId = friend.SentByUserId == user.Id ? friend.SentToUserId : friend.SentByUserId` — the same ternary shape already used for `Username`, just resolving the id instead of the nav's `Username`.
- `docs/ROUTINES_PLAN.md`: ticked the B6 checkbox.

No other endpoint behaviour changed. `Username`/`Date`/`SharedExpenses` are unaffected.

## Testing

Added `Tests/Expense.API.IntegrationTests/FriendsTests.cs` (no plain CRUD suite existed yet for `getFriends`, per the spec's fallback):
- `GetFriends_returns_the_counterparty_userId_when_caller_sent_the_request` — caller is the `SentBy` party.
- `GetFriends_returns_the_counterparty_userId_when_caller_received_the_request` — caller is the `SentTo` party.

Both drive the real friend-request flow (`sendRequest` → look up the persisted `FriendRequest.NotificationId` via `WithDbAsync` → `acceptRequest`) and assert `GetFriends()` returns the correct counterparty id for both directions.

**Deviation from the runner protocol's quality gates:** this sandbox has no `dotnet` SDK installed, and outbound access to `dot.net`/apt sources to install one is blocked by the environment's network policy (confirmed: `curl https://dot.net/v1/dotnet-install.sh` → `CONNECT tunnel failed, response 403`; `apt-get install dotnet-sdk-7.0` → package not found). I could not run `dotnet build` or `dotnet test Tests/Expense.API.IntegrationTests` locally in this run. The change itself is a two-line, low-risk addition (a new property plus one ternary assignment, following an existing pattern in the same method), and I reviewed the diff and all call sites of `FriendsListDto` by hand to confirm there's nothing else to update. `.github/workflows/integration-tests.yml` will run the full suite on this PR and is the gate of record — please treat that CI run as the actual verification before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9vyBYCkS5roWsprNVT2hv)_