### PR TITLE
routine(B7): Require friendship before adding a user to an expense split

### DIFF
--- a/Repositories/Expense/ExpenseRepository.cs
+++ b/Repositories/Expense/ExpenseRepository.cs
@@ -67,6 +67,20 @@ namespace Expense.API.Repositories.Expense
 
             if (user != null && expense != null)
             {
+                var currentUser = await GetCurrentUserAsync();
+                if (expenseUser.UserId != currentUser.Id)
+                {
+                    var areFriends = await userDocumentsDbContext.FriendRequests.AnyAsync(
+                        fr => ((fr.SentByUserId == currentUser.Id && fr.SentToUserId == expenseUser.UserId)
+                               || (fr.SentByUserId == expenseUser.UserId && fr.SentToUserId == currentUser.Id))
+                              && fr.IsAccepted == 1);
+
+                    if (!areFriends)
+                    {
+                        throw new Exception("Users must be friends before sharing an expense.");
+                    }
+                }
+
                 var expenseUserExists = await userDocumentsDbContext.ExpenseUsers.FirstOrDefaultAsync(
                                             expenseUser => expenseUser.ExpenseId == expense.Id
                                             && expenseUser.UserId == user.Id);

--- a/Tests/Expense.API.IntegrationTests/AssignUsersTests.cs
+++ b/Tests/Expense.API.IntegrationTests/AssignUsersTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Net.Http.Json;
+using Expense.API.IntegrationTests.Infrastructure;
+using Expense.API.Models.DTO;
+using FluentAssertions;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+public class AssignUsersTests : IntegrationTestBase
+{
+    public AssignUsersTests(CustomWebAppFactory factory) : base(factory) { }
+
+    private static async Task<ExpenseDto> CreateExpenseAsync(HttpClient client, string title, string description)
+    {
+        var res = await client.PostAsync($"/api/Expense?title={title}&description={description}", null);
+        res.StatusCode.Should().Be(HttpStatusCode.OK, await res.Content.ReadAsStringAsync());
+        return (await res.Content.ReadFromJsonAsync<ExpenseDto>())!;
+    }
+
+    [Fact]
+    public async Task AddUser_with_a_non_friend_returns_400_with_the_expected_message()
+    {
+        var owner = await RegisterAndLoginAsync("owner");
+        var stranger = await RegisterAndLoginAsync("stranger");
+        var created = await CreateExpenseAsync(owner.Client, "Dinner", "Shared dinner");
+
+        var add = await owner.Client.PostAsync($"/api/Expense/{created.Id}/addUser?userId={stranger.Id}", null);
+
+        add.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await add.Content.ReadAsStringAsync()).Should().Contain("Users must be friends before sharing an expense.");
+    }
+
+    [Fact]
+    public async Task AddUser_with_an_accepted_friend_returns_200_and_shares_recalculate()
+    {
+        var owner = await RegisterAndLoginAsync("owner");
+        var friend = await RegisterAndLoginAsync("friend");
+        await BefriendAsync(owner, friend);
+        var created = await CreateExpenseAsync(owner.Client, "Dinner", "Shared dinner");
+
+        var add = await owner.Client.PostAsync($"/api/Expense/{created.Id}/addUser?userId={friend.Id}", null);
+        add.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var res = await owner.Client.GetAsync($"/api/Expense/{created.Id}/getAssignedUsers");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var users = await res.Content.ReadFromJsonAsync<List<System.Text.Json.JsonElement>>();
+        users!.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task AddUser_with_a_pending_friend_request_returns_400()
+    {
+        var owner = await RegisterAndLoginAsync("owner");
+        var pending = await RegisterAndLoginAsync("pending");
+        var created = await CreateExpenseAsync(owner.Client, "Dinner", "Shared dinner");
+
+        var sendRequest = await owner.Client.PostAsJsonAsync("/api/Friends/sendRequest", new UserDto
+        {
+            Id = pending.Id,
+            Username = pending.UserName
+        });
+        sendRequest.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var add = await owner.Client.PostAsync($"/api/Expense/{created.Id}/addUser?userId={pending.Id}", null);
+
+        add.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await add.Content.ReadAsStringAsync()).Should().Contain("Users must be friends before sharing an expense.");
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/ExpenseCrudTests.cs
+++ b/Tests/Expense.API.IntegrationTests/ExpenseCrudTests.cs
@@ -65,7 +65,8 @@ public class ExpenseCrudTests : IntegrationTestBase
     public async Task AddUser_then_getAssignedUsers_lists_creator_and_peer()
     {
         var user = await RegisterAndLoginAsync("assign");
-        var peer = await CreateBusinessUserAsync("peer");
+        var peer = await RegisterAndLoginAsync("peer");
+        await BefriendAsync(user, peer);
         var created = await CreateExpenseAsync(user.Client, "Dinner", "Shared dinner");
 
         var add = await user.Client.PostAsync($"/api/Expense/{created.Id}/addUser?userId={peer.Id}", null);

--- a/Tests/Expense.API.IntegrationTests/FriendsTests.cs
+++ b/Tests/Expense.API.IntegrationTests/FriendsTests.cs
@@ -1,10 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
 using Expense.API.IntegrationTests.Infrastructure;
-using Expense.API.Models.Domain;
 using Expense.API.Models.DTO;
 using FluentAssertions;
-using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 namespace Expense.API.IntegrationTests;
@@ -12,28 +10,6 @@ namespace Expense.API.IntegrationTests;
 public class FriendsTests : IntegrationTestBase
 {
     public FriendsTests(CustomWebAppFactory factory) : base(factory) { }
-
-    private async Task BefriendAsync(TestUser sender, TestUser recipient)
-    {
-        var sendRequest = await sender.Client.PostAsJsonAsync("/api/Friends/sendRequest", new UserDto
-        {
-            Id = recipient.Id,
-            Username = recipient.UserName
-        });
-        sendRequest.StatusCode.Should().Be(HttpStatusCode.NoContent);
-
-        Guid notificationId = Guid.Empty;
-        await WithDbAsync(async db =>
-        {
-            var friendRequest = await db.FriendRequests.FirstOrDefaultAsync(
-                fr => fr.SentByUserId == sender.Id && fr.SentToUserId == recipient.Id);
-            friendRequest.Should().NotBeNull();
-            notificationId = friendRequest!.NotificationId;
-        });
-
-        var acceptRequest = await recipient.Client.PostAsJsonAsync("/api/Friends/acceptRequest", notificationId.ToString());
-        acceptRequest.StatusCode.Should().Be(HttpStatusCode.NoContent);
-    }
 
     [Fact]
     public async Task GetFriends_returns_the_counterparty_userId_when_caller_sent_the_request()

--- a/Tests/Expense.API.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/Tests/Expense.API.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -86,4 +86,27 @@ public abstract class IntegrationTestBase
         });
         return user;
     }
+
+    /// <summary>Sends a friend request from sender to recipient through the real API and accepts it.</summary>
+    protected async Task BefriendAsync(TestUser sender, TestUser recipient)
+    {
+        var sendRequest = await sender.Client.PostAsJsonAsync("/api/Friends/sendRequest", new UserDto
+        {
+            Id = recipient.Id,
+            Username = recipient.UserName
+        });
+        sendRequest.StatusCode.Should().Be(System.Net.HttpStatusCode.NoContent);
+
+        Guid notificationId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var friendRequest = await db.FriendRequests.FirstOrDefaultAsync(
+                fr => fr.SentByUserId == sender.Id && fr.SentToUserId == recipient.Id);
+            friendRequest.Should().NotBeNull();
+            notificationId = friendRequest!.NotificationId;
+        });
+
+        var acceptRequest = await recipient.Client.PostAsJsonAsync("/api/Friends/acceptRequest", notificationId.ToString());
+        acceptRequest.StatusCode.Should().Be(System.Net.HttpStatusCode.NoContent);
+    }
 }

--- a/docs/ROUTINES_PLAN.md
+++ b/docs/ROUTINES_PLAN.md
@@ -122,7 +122,7 @@ POST /api/Expense/{id}/addUser?userId=   (existing endpoint; after B7 friend-gat
 - [x] **B4 — Budget model, repository, endpoints**
 - [x] **B5 — Budget threshold alerts**
 - [x] **B6 — Expose `userId` on `GET /api/Friends/getFriends`**
-- [ ] **B7 — Require friendship before adding a user to an expense split**
+- [x] **B7 — Require friendship before adding a user to an expense split**
 
 ---
 


### PR DESCRIPTION
## What

Closes the gap where `POST /api/Expense/{id}/addUser?userId=` accepted any authenticated caller's `userId` for any expense, with no relationship check server-side (the frontend picker already limited this to accepted friends, but nothing stopped a direct API call).

- `ExpenseRepository.CreateExpenseUserAsync` now resolves the caller (`GetCurrentUserAsync`, same lookup used elsewhere in the file) and, when `expenseUser.UserId` differs from the caller's own id, requires an accepted `FriendRequest` row between the two users (either direction, `IsAccepted == 1` — same predicate as `FriendRequestRepository.GetFriends`/`GetDropdownUsers`). If none exists, throws `"Users must be friends before sharing an expense."`, which `ExpenseController.PostUserToExpense` already maps to `400`.
- The check is skipped when `expenseUser.UserId == callerId` (self-assignment on expense creation), so `CreateExpenseAsync`'s auto-assign-the-creator flow is unaffected.
- No change to `CreateExpenseAsync`, `Put`, ownership/authorization semantics, or any other endpoint, per the phase's explicit scope.

## Tests

- New `Tests/Expense.API.IntegrationTests/AssignUsersTests.cs`:
  - non-friend `addUser` → `400` with the exact message.
  - accepted friend `addUser` → `200`, and `getAssignedUsers` share-recalculation still works.
  - pending (not-yet-accepted) friend request → still `400`.
- Fixed the pre-existing `AddUser_then_getAssignedUsers_lists_creator_and_peer` test in `ExpenseCrudTests.cs`, which added a non-friend peer — it now registers a second logged-in user and befriends them first, matching the new server-side rule.
- Extracted the `BefriendAsync` helper (send + accept a friend request through the real API) that `FriendsTests.cs` already had as a private method up into `IntegrationTestBase`, so `ExpenseCrudTests.cs` and `AssignUsersTests.cs` can reuse it instead of duplicating it a third time.

## How it was verified

- `dotnet build` (`ExpenseApi.sln`): succeeds, 0 errors, no new warnings (same pre-existing `CS8618`/`NU190x` warnings as before this change).
- `dotnet build Tests/Expense.API.IntegrationTests`: succeeds, 0 errors.
- `dotnet test Tests/Expense.API.IntegrationTests`: **could not be run in this sandbox** — the Docker daemon itself is unavailable, not just an image-pull restriction. `docker info` reports `failed to connect to the docker API at unix:///var/run/docker.sock: ... no such file or directory`, and starting it via `service docker start` fails with `ulimit: error setting limit (Operation not permitted)` (no systemd in this container, and the sandbox doesn't allow the daemon to raise the limits it wants). GitHub Actions (`.github/workflows/integration-tests.yml`) runs the full suite on this PR regardless and is the gate of record.

## Deviations from spec

None beyond the above test-infrastructure note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFyJqZSmZESGgoKw8twPmD)_