### PR TITLE
feat(expenses): manual amount entry + receipt-lock toggle on create

### DIFF
--- a/Controllers/ExpenseController.cs
+++ b/Controllers/ExpenseController.cs
@@ -47,6 +47,11 @@ namespace Expense.API.Controllers
                 {
                     return NotFound($"No expenses found for the logged in user");
                 }
+                var scannedReceiptsTotals = await expenseRepository.GetScannedReceiptsTotalsAsync(expenses.Select(e => e.Id));
+                foreach (var dto in expensesDto)
+                {
+                    dto.ScannedReceiptsTotal = scannedReceiptsTotals.GetValueOrDefault(Guid.Parse(dto.Id));
+                }
                 var result = new
                 {
                     Expenses = expensesDto,
@@ -81,6 +86,11 @@ namespace Expense.API.Controllers
                 if (expensesDto == null || !expensesDto.Any())
                 {
                     return NotFound($"No expenses found for the logged in user");
+                }
+                var scannedReceiptsTotals = await expenseRepository.GetScannedReceiptsTotalsAsync(expenses.Select(e => e.Id));
+                foreach (var dto in expensesDto)
+                {
+                    dto.ScannedReceiptsTotal = scannedReceiptsTotals.GetValueOrDefault(Guid.Parse(dto.Id));
                 }
                 var result = new
                 {
@@ -210,26 +220,26 @@ namespace Expense.API.Controllers
 
         // POST api/values
         [HttpPost]
-        public async Task<IActionResult> Post(string title, string description)
+        public async Task<IActionResult> Post([FromBody] AddExpenseDto addExpenseDto)
         {
-
-            AddExpenseDto addExpenseDto = new AddExpenseDto();
-            addExpenseDto.Amount = 0;
-
-
-            if (title != null && description != null)
+            if (addExpenseDto?.Title != null && addExpenseDto.Description != null)
             {
-                addExpenseDto.Description = description;
-                addExpenseDto.Title = title;
-                var expenseCreated = await expenseRepository.CreateExpenseAsync(mapper.Map<ExpenseModel>(addExpenseDto));
-                var expenseDto = mapper.Map<ExpenseDto>(expenseCreated);
-
-                if (expenseCreated != null)
+                try
                 {
-                    var expenseUser = new ExpenseUser(expenseCreated.Id, expenseCreated.CreatedById, null);
-                    await expenseRepository.CreateExpenseUserAsync(expenseUser);
-                    return Ok(expenseDto);
+                    var expenseCreated = await expenseRepository.CreateExpenseAsync(mapper.Map<ExpenseModel>(addExpenseDto));
+                    var expenseDto = mapper.Map<ExpenseDto>(expenseCreated);
 
+                    if (expenseCreated != null)
+                    {
+                        var expenseUser = new ExpenseUser(expenseCreated.Id, expenseCreated.CreatedById, null);
+                        await expenseRepository.CreateExpenseUserAsync(expenseUser);
+                        return Ok(expenseDto);
+
+                    }
+                }
+                catch (Exception e)
+                {
+                    return BadRequest(e.Message);
                 }
             }
             return BadRequest("Not created expense");

--- a/Migrations/UserDocumentsDb/20260714101153_AddExpenseAllowReceipts.Designer.cs
+++ b/Migrations/UserDocumentsDb/20260714101153_AddExpenseAllowReceipts.Designer.cs
@@ -4,6 +4,7 @@ using Expense.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Expense.API.Migrations.UserDocumentsDb
 {
     [DbContext(typeof(UserDocumentsDbContext))]
-    partial class UserDocumentsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714101153_AddExpenseAllowReceipts")]
+    partial class AddExpenseAllowReceipts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/UserDocumentsDb/20260714101153_AddExpenseAllowReceipts.cs
+++ b/Migrations/UserDocumentsDb/20260714101153_AddExpenseAllowReceipts.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Expense.API.Migrations.UserDocumentsDb
+{
+    /// <inheritdoc />
+    public partial class AddExpenseAllowReceipts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AllowReceipts",
+                table: "Expenses",
+                type: "bit",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AllowReceipts",
+                table: "Expenses");
+        }
+    }
+}

--- a/Models/DTO/AddExpenseDto.cs
+++ b/Models/DTO/AddExpenseDto.cs
@@ -11,6 +11,7 @@ namespace Expense.API.Models.DTO
         public string Description { get; set; }
         public decimal Amount { get; set; }
         public string? Category { get; set; }
+        public bool AllowReceipts { get; set; } = true;
     }
 }
 

--- a/Models/DTO/ExpenseDto.cs
+++ b/Models/DTO/ExpenseDto.cs
@@ -13,6 +13,7 @@ namespace Expense.API.Models.DTO
         public string Description { get; set; }
         public decimal Amount { get; set; }
         public string CreatedAt { get; set; }
+        public decimal ScannedReceiptsTotal { get; set; }
         //public ICollection<Document> Documents { get; set; }
         //public List<string> UserIds { get; set; }
     }

--- a/Models/DTO/UpdateExpenseDto.cs
+++ b/Models/DTO/UpdateExpenseDto.cs
@@ -3,17 +3,19 @@ namespace Expense.API.Models.DTO
 {
 	public class UpdateExpenseDto
 	{
-		public UpdateExpenseDto(string id, string title, string description, string? category = null)
+		public UpdateExpenseDto(string id, string title, string description, string? category = null, decimal? amount = null)
 		{
 			this.Id = id;
 			this.Description = description;
 			this.Title = title;
 			this.Category = category;
+			this.Amount = amount;
 		}
         public string Id { get; set; }
         public string Title { get; set; }
         public string Description { get; set; }
         public string? Category { get; set; }
+        public decimal? Amount { get; set; }
     }
 }
 

--- a/Models/Domain/Expense/Expense.cs
+++ b/Models/Domain/Expense/Expense.cs
@@ -21,6 +21,12 @@
         /// </summary>
         public string? Category { get; set; }
 
+        /// <summary>
+        /// Set only at creation. When false, this expense can never have receipt documents
+        /// uploaded or scanned - the amount is fully manual.
+        /// </summary>
+        public bool AllowReceipts { get; set; } = true;
+
         //Navgational Properties
 
         /// <summary>

--- a/Repositories/Documents/DocumentRepository.cs
+++ b/Repositories/Documents/DocumentRepository.cs
@@ -589,6 +589,11 @@ namespace Expense.API.Repositories.Documents
             var expense = await userDocumentsDbContext.Expenses.FirstOrDefaultAsync(e => e.Id.Equals(expenseId));
             if (userFound != null && expense !=null)
             {
+                if (!expense.AllowReceipts)
+                {
+                    throw new Exception("This expense does not accept receipt uploads.");
+                }
+
                 var bucketName = configuration["AWS:BucketName"];
                 using (var memoryStream = new MemoryStream())
                 {

--- a/Repositories/Expense/ExpenseRepository.cs
+++ b/Repositories/Expense/ExpenseRepository.cs
@@ -31,6 +31,11 @@ namespace Expense.API.Repositories.Expense
 
         public async Task<ExpenseModel> CreateExpenseAsync(ExpenseModel expense)
         {
+            if (expense.Amount < 0)
+            {
+                throw new Exception("Amount cannot be negative.");
+            }
+
             // Retrieve the current logged-in user from the HttpContext
             var userName = httpContextAccessor.HttpContext?.User?.Claims
                              .FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value;
@@ -410,11 +415,41 @@ namespace Expense.API.Repositories.Expense
                 expense.Title = updateExpenseDto.Title;
                 expense.Description = updateExpenseDto.Description;
                 expense.Category = updateExpenseDto.Category;
+
+                if (updateExpenseDto.Amount.HasValue)
+                {
+                    if (updateExpenseDto.Amount.Value < 0)
+                    {
+                        throw new Exception("Amount cannot be negative.");
+                    }
+
+                    var scannedReceiptsTotal = await userDocumentsDbContext.DocumentJobResults
+                        .Where(r => r.ExpenseId == expense.Id && r.Status == 1)
+                        .SumAsync(r => (decimal?)r.Total) ?? 0m;
+
+                    if (updateExpenseDto.Amount.Value < scannedReceiptsTotal)
+                    {
+                        throw new Exception($"Amount cannot be less than the total of scanned receipts (${scannedReceiptsTotal}).");
+                    }
+
+                    expense.Amount = updateExpenseDto.Amount.Value;
+                }
+
                 await userDocumentsDbContext.SaveChangesAsync();
                 await CheckBudgetThresholdAsync(expense);
                 return expense;
             }
             throw new Exception("Update Failed, Expense Not found");
+        }
+
+        public async Task<Dictionary<Guid, decimal>> GetScannedReceiptsTotalsAsync(IEnumerable<Guid> expenseIds)
+        {
+            var ids = expenseIds.ToList();
+            return await userDocumentsDbContext.DocumentJobResults
+                .Where(r => ids.Contains(r.ExpenseId) && r.Status == 1)
+                .GroupBy(r => r.ExpenseId)
+                .Select(g => new { ExpenseId = g.Key, Total = g.Sum(r => r.Total) })
+                .ToDictionaryAsync(x => x.ExpenseId, x => x.Total);
         }
 
         // ----- Dashboard -----

--- a/Repositories/Expense/IExpenseRepository.cs
+++ b/Repositories/Expense/IExpenseRepository.cs
@@ -84,11 +84,16 @@ namespace Expense.API.Repositories.Expense
         public Task<Boolean> RemoveExpense(Guid id);
 
         /// <summary>
-        /// Update expense 
+        /// Update expense
         /// </summary>
         /// <param name="updateExpenseDto"></param>
         /// <returns></returns>
         public Task<ExpenseModel> UpdateExpenseAsync(UpdateExpenseDto updateExpenseDto);
+
+        /// <summary>
+        /// Sum of successfully-scanned receipt totals per expense, for the given expense ids.
+        /// </summary>
+        public Task<Dictionary<Guid, decimal>> GetScannedReceiptsTotalsAsync(IEnumerable<Guid> expenseIds);
 
         /// <summary>
         /// Get textract result for the table

--- a/Repositories/ExpenseAnalysis/ExpenseAnalysis.cs
+++ b/Repositories/ExpenseAnalysis/ExpenseAnalysis.cs
@@ -407,6 +407,11 @@ namespace Expense.API.Repositories.ExpenseAnalysis
                 throw new Exception("Expense does not exist.");
             }
 
+            if (!expenseExists.AllowReceipts)
+            {
+                throw new Exception("This expense does not accept receipt processing.");
+            }
+
             // Find all the documents related to the expense
             DocumentModel? document = await userDocumentsDbContext.Documents
                 .Where(doc => doc.Id == docId && doc.ExpenseId == expenseId)

--- a/Tests/Expense.API.IntegrationTests/AssignUsersTests.cs
+++ b/Tests/Expense.API.IntegrationTests/AssignUsersTests.cs
@@ -13,7 +13,7 @@ public class AssignUsersTests : IntegrationTestBase
 
     private static async Task<ExpenseDto> CreateExpenseAsync(HttpClient client, string title, string description)
     {
-        var res = await client.PostAsync($"/api/Expense?title={title}&description={description}", null);
+        var res = await client.PostAsJsonAsync("/api/Expense", new AddExpenseDto { Title = title, Description = description });
         res.StatusCode.Should().Be(HttpStatusCode.OK, await res.Content.ReadAsStringAsync());
         return (await res.Content.ReadFromJsonAsync<ExpenseDto>())!;
     }

--- a/Tests/Expense.API.IntegrationTests/ExpenseCrudTests.cs
+++ b/Tests/Expense.API.IntegrationTests/ExpenseCrudTests.cs
@@ -14,9 +14,16 @@ public class ExpenseCrudTests : IntegrationTestBase
 
     private sealed record ExpenseList(List<ExpenseDto> Expenses, int TotalRows);
 
-    private static async Task<ExpenseDto> CreateExpenseAsync(HttpClient client, string title, string description)
+    private static async Task<ExpenseDto> CreateExpenseAsync(HttpClient client, string title, string description,
+        decimal amount = 0, bool allowReceipts = true)
     {
-        var res = await client.PostAsync($"/api/Expense?title={title}&description={description}", null);
+        var res = await client.PostAsJsonAsync("/api/Expense", new AddExpenseDto
+        {
+            Title = title,
+            Description = description,
+            Amount = amount,
+            AllowReceipts = allowReceipts
+        });
         res.StatusCode.Should().Be(HttpStatusCode.OK, await res.Content.ReadAsStringAsync());
         return (await res.Content.ReadFromJsonAsync<ExpenseDto>())!;
     }
@@ -110,5 +117,88 @@ public class ExpenseCrudTests : IntegrationTestBase
         res.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await res.Content.ReadFromJsonAsync<JsonElement>();
         body.GetProperty("totalRows").GetInt32().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Create_persists_manual_amount_as_starting_value()
+    {
+        var user = await RegisterAndLoginAsync("amt");
+
+        var created = await CreateExpenseAsync(user.Client, "Groceries", "Weekly shop", amount: 50m);
+
+        created.Amount.Should().Be(50m);
+    }
+
+    [Fact]
+    public async Task Create_without_receipts_blocks_document_upload()
+    {
+        var user = await RegisterAndLoginAsync("norcpt");
+        var created = await CreateExpenseAsync(user.Client, "Cash tip", "No receipt", amount: 20m, allowReceipts: false);
+
+        using var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(new byte[] { 1, 2, 3 });
+        fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
+        content.Add(fileContent, "file", "receipt.png");
+
+        var res = await user.Client.PostAsync($"/api/Expense/{created.Id}/uploadDoc", content);
+
+        res.IsSuccessStatusCode.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Update_amount_below_scanned_receipts_floor_is_rejected()
+    {
+        var user = await RegisterAndLoginAsync("floorlow");
+        var created = await CreateExpenseAsync(user.Client, "Dinner", "Team dinner", amount: 200m);
+
+        await WithDbAsync(async db =>
+        {
+            var doc = SeedData.AddReceipt(db, user.Id, Guid.Parse(created.Id), DateTime.UtcNow);
+            SeedData.AddDocumentJobResult(db, user.Id, Guid.Parse(created.Id), doc.Id, 100m);
+            await db.SaveChangesAsync();
+        });
+
+        var res = await user.Client.PutAsJsonAsync($"/api/Expense/{created.Id}",
+            new UpdateExpenseDto(created.Id, "Dinner", "Team dinner", amount: 50m));
+
+        res.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+
+        var fetched = await user.Client.GetFromJsonAsync<ExpenseDto>($"/api/Expense/{created.Id}");
+        fetched!.Amount.Should().Be(200m);
+    }
+
+    [Fact]
+    public async Task Update_amount_at_or_above_floor_succeeds()
+    {
+        var user = await RegisterAndLoginAsync("floorok");
+        var created = await CreateExpenseAsync(user.Client, "Dinner", "Team dinner", amount: 200m);
+
+        await WithDbAsync(async db =>
+        {
+            var doc = SeedData.AddReceipt(db, user.Id, Guid.Parse(created.Id), DateTime.UtcNow);
+            SeedData.AddDocumentJobResult(db, user.Id, Guid.Parse(created.Id), doc.Id, 100m);
+            await db.SaveChangesAsync();
+        });
+
+        var res = await user.Client.PutAsJsonAsync($"/api/Expense/{created.Id}",
+            new UpdateExpenseDto(created.Id, "Dinner", "Team dinner", amount: 150m));
+
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await res.Content.ReadFromJsonAsync<ExpenseDto>();
+        updated!.Amount.Should().Be(150m);
+    }
+
+    [Fact]
+    public async Task Update_without_amount_leaves_existing_amount_untouched()
+    {
+        var user = await RegisterAndLoginAsync("noamt");
+        var created = await CreateExpenseAsync(user.Client, "Old", "Old desc", amount: 42m);
+
+        var res = await user.Client.PutAsJsonAsync($"/api/Expense/{created.Id}",
+            new UpdateExpenseDto(created.Id, "New", "New desc"));
+
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await res.Content.ReadFromJsonAsync<ExpenseDto>();
+        updated!.Amount.Should().Be(42m);
     }
 }

--- a/Tests/Expense.API.IntegrationTests/Infrastructure/SeedData.cs
+++ b/Tests/Expense.API.IntegrationTests/Infrastructure/SeedData.cs
@@ -54,4 +54,22 @@ public static class SeedData
         db.ExpenseUsers.Add(share);
         return share;
     }
+
+    /// <summary>A scanned-receipt result for a document: Total feeds the ScannedReceiptsTotal floor.</summary>
+    public static DocumentJobResult AddDocumentJobResult(UserDocumentsDbContext db, Guid createdById,
+        Guid expenseId, Guid documentId, decimal total, byte status = 1)
+    {
+        var jobResult = new DocumentJobResult
+        {
+            Id = Guid.NewGuid(),
+            JobId = Guid.NewGuid().ToString(),
+            Status = status,
+            CreatedById = createdById,
+            ExpenseId = expenseId,
+            DocumentId = documentId,
+            Total = total
+        };
+        db.DocumentJobResults.Add(jobResult);
+        return jobResult;
+    }
 }


### PR DESCRIPTION
Expenses could previously only get an amount via the async OCR/Textract pipeline. Adds a manual Amount field and an AllowReceipts toggle at creation (hard lock: once set to "without receipts", the expense can never have documents attached or scanned - enforced both server-side and by hiding the UI affordance). The existing additive OCR mechanic (expense.Amount += scanned total) is unchanged, so the manual amount just becomes the correct starting point instead of a hardcoded 0.

Amount also becomes editable via the existing Edit dialogs, guarded by a new floor: it can never be set below the sum of that expense's successfully-scanned receipt totals (ScannedReceiptsTotal, now returned on list endpoints so the UI can validate without a round trip).