### PR TITLE
fix(friends): populate real shared-expenses count on friends list

### DIFF
--- a/Repositories/FriendRequest/FriendRequestRepository.cs
+++ b/Repositories/FriendRequest/FriendRequestRepository.cs
@@ -138,19 +138,43 @@ namespace Expense.API.Repositories.FriendRequest
 
             if (user != null)
             {
-                var friends = await userDocumentsDbContext.FriendRequests
+                var friendLinks = await userDocumentsDbContext.FriendRequests
                     .Where(friend =>
                         (friend.SentByUserId == user.Id || friend.SentToUserId == user.Id) &&
                         friend.IsAccepted == 1)
-                    .Select(friend =>
-                        new FriendsListDto
-                        {
-                            UserId = friend.SentByUserId == user.Id ? friend.SentToUserId : friend.SentByUserId,
-                            Username = friend.SentByUserId == user.Id ? friend.SentToUser.Username : friend.SentByUser.Username,
-                            AcceptedAt = (DateTime)friend.AcceptedAt,
-                            SharedExpenses = new List<ExpenseDto>()
-                        })
+                    .Select(friend => new
+                    {
+                        FriendUserId = friend.SentByUserId == user.Id ? friend.SentToUserId : friend.SentByUserId,
+                        Username = friend.SentByUserId == user.Id ? friend.SentToUser.Username : friend.SentByUser.Username,
+                        friend.AcceptedAt
+                    })
                     .ToListAsync();
+
+                var friends = new List<FriendsListDto>();
+                foreach (var link in friendLinks)
+                {
+                    var sharedExpenses = await userDocumentsDbContext.Expenses
+                        .Where(e =>
+                            (e.CreatedById == user.Id || e.ExpenseUsers.Any(eu => eu.UserId == user.Id)) &&
+                            (e.CreatedById == link.FriendUserId || e.ExpenseUsers.Any(eu => eu.UserId == link.FriendUserId)))
+                        .Select(e => new ExpenseDto
+                        {
+                            Id = e.Id.ToString(),
+                            Title = e.Title,
+                            Description = e.Description,
+                            Amount = e.Amount,
+                            CreatedAt = e.CreatedAt.ToString()
+                        })
+                        .ToListAsync();
+
+                    friends.Add(new FriendsListDto
+                    {
+                        UserId = link.FriendUserId,
+                        Username = link.Username,
+                        AcceptedAt = (DateTime)link.AcceptedAt,
+                        SharedExpenses = sharedExpenses
+                    });
+                }
                 return friends;
             }
             else

--- a/Tests/Expense.API.IntegrationTests/FriendsTests.cs
+++ b/Tests/Expense.API.IntegrationTests/FriendsTests.cs
@@ -40,4 +40,35 @@ public class FriendsTests : IntegrationTestBase
         friends.Should().ContainSingle(f => f.Username == sender.UserName)
             .Which.UserId.Should().Be(sender.Id);
     }
+
+    [Fact]
+    public async Task GetFriends_reports_the_actual_count_of_expenses_shared_with_that_friend()
+    {
+        var user = await RegisterAndLoginAsync("user");
+        var friend = await RegisterAndLoginAsync("friend");
+        var stranger = await RegisterAndLoginAsync("stranger");
+        await BefriendAsync(user, friend);
+
+        await WithDbAsync(async db =>
+        {
+            var shared1 = SeedData.AddExpense(db, user.Id, "Dinner", 40m, "Dining", DateTime.UtcNow);
+            SeedData.AddShare(db, shared1.Id, friend.Id, 20);
+
+            var shared2 = SeedData.AddExpense(db, friend.Id, "Groceries", 60m, "Groceries", DateTime.UtcNow);
+            SeedData.AddShare(db, shared2.Id, user.Id, 30);
+
+            // Not shared with `friend` - should not be counted.
+            var soloExpense = SeedData.AddExpense(db, user.Id, "Solo", 15m, "Misc", DateTime.UtcNow);
+            SeedData.AddShare(db, soloExpense.Id, stranger.Id, 7.5);
+
+            await db.SaveChangesAsync();
+        });
+
+        var res = await user.Client.GetAsync("/api/Friends/getFriends");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var friends = await res.Content.ReadFromJsonAsync<List<FriendsListDto>>();
+
+        friends.Should().ContainSingle(f => f.Username == friend.UserName)
+            .Which.SharedExpenses.Should().HaveCount(2);
+    }
 }


### PR DESCRIPTION
GetFriends() always returned SharedExpenses as a hardcoded empty list, so the frontend showed "0 shared expenses" for every friend regardless of actual history. Now queries expenses where both the user and the friend participate (as creator or via ExpenseUsers).