### PR TITLE
routine(B8): LineItem/LineItemAssignment schema

### DIFF
--- a/Data/UserDocumentsDbContext.cs
+++ b/Data/UserDocumentsDbContext.cs
@@ -20,6 +20,8 @@ namespace Expense.API.Data
         public DbSet<FriendRequest> FriendRequests { get; set; }
         public DbSet<Settlement> Settlements { get; set; }
         public DbSet<Budget> Budgets { get; set; }
+        public DbSet<LineItem> LineItems { get; set; }
+        public DbSet<LineItemAssignment> LineItemAssignments { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -85,6 +87,33 @@ namespace Expense.API.Data
                 .HasOne(b => b.User)
                 .WithMany()
                 .HasForeignKey(b => b.UserId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<LineItem>()
+                .HasOne(li => li.DocumentJobResult)
+                .WithMany()
+                .HasForeignKey(li => li.DocumentJobResultId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<LineItem>()
+                .HasOne(li => li.Expense)
+                .WithMany()
+                .HasForeignKey(li => li.ExpenseId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<LineItemAssignment>()
+                .HasKey(la => new { la.LineItemId, la.UserId });
+
+            modelBuilder.Entity<LineItemAssignment>()
+                .HasOne(la => la.LineItem)
+                .WithMany(li => li.Assignments)
+                .HasForeignKey(la => la.LineItemId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<LineItemAssignment>()
+                .HasOne(la => la.User)
+                .WithMany()
+                .HasForeignKey(la => la.UserId)
                 .OnDelete(DeleteBehavior.Restrict);
         }
     }

--- a/ExpenseAnalyserDbScripts/15-line-items-and-assignments.sql
+++ b/ExpenseAnalyserDbScripts/15-line-items-and-assignments.sql
@@ -1,0 +1,77 @@
+USE ExpenseAnalyserDb;
+GO
+
+-- LineItems: normalized, per-row line items extracted from a DocumentJobResult's scanned
+-- receipt, so individual rows can be assigned to users (denormalized ExpenseId lets a
+-- multi-document expense's items be queried/aggregated without joining through DocumentJobResult).
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE Name = N'LineItems' AND Schema_Id = Schema_Id(N'dbo'))
+BEGIN
+    CREATE TABLE [dbo].[LineItems](
+        [Id] [uniqueidentifier] NOT NULL,
+        [DocumentJobResultId] [uniqueidentifier] NOT NULL,
+        [ExpenseId] [uniqueidentifier] NOT NULL,
+        [SortOrder] [int] NOT NULL,
+        [Description] [nvarchar](max) NULL,
+        [Quantity] [nvarchar](max) NULL,
+        [Amount] [decimal](18, 2) NULL,
+        [RawFieldsJson] [nvarchar](max) NOT NULL,
+     CONSTRAINT [PK_LineItems] PRIMARY KEY CLUSTERED
+    (
+        [Id] ASC
+    )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+    ) ON [PRIMARY]
+
+    CREATE NONCLUSTERED INDEX [IX_LineItems_DocumentJobResultId] ON [dbo].[LineItems]
+    (
+        [DocumentJobResultId] ASC
+    )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+
+    CREATE NONCLUSTERED INDEX [IX_LineItems_ExpenseId] ON [dbo].[LineItems]
+    (
+        [ExpenseId] ASC
+    )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+
+    ALTER TABLE [dbo].[LineItems] WITH CHECK ADD CONSTRAINT [FK_LineItems_DocumentJobResults_DocumentJobResultId] FOREIGN KEY([DocumentJobResultId])
+    REFERENCES [dbo].[DocumentJobResults] ([Id])
+    ON DELETE CASCADE
+
+    ALTER TABLE [dbo].[LineItems] CHECK CONSTRAINT [FK_LineItems_DocumentJobResults_DocumentJobResultId]
+
+    ALTER TABLE [dbo].[LineItems] WITH CHECK ADD CONSTRAINT [FK_LineItems_Expenses_ExpenseId] FOREIGN KEY([ExpenseId])
+    REFERENCES [dbo].[Expenses] ([Id])
+
+    ALTER TABLE [dbo].[LineItems] CHECK CONSTRAINT [FK_LineItems_Expenses_ExpenseId]
+END
+GO
+
+-- LineItemAssignments: which users a line item is split across.
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE Name = N'LineItemAssignments' AND Schema_Id = Schema_Id(N'dbo'))
+BEGIN
+    CREATE TABLE [dbo].[LineItemAssignments](
+        [LineItemId] [uniqueidentifier] NOT NULL,
+        [UserId] [uniqueidentifier] NOT NULL,
+        [AssignedAt] [datetime2](7) NOT NULL,
+     CONSTRAINT [PK_LineItemAssignments] PRIMARY KEY CLUSTERED
+    (
+        [LineItemId] ASC,
+        [UserId] ASC
+    )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+    ) ON [PRIMARY]
+
+    CREATE NONCLUSTERED INDEX [IX_LineItemAssignments_UserId] ON [dbo].[LineItemAssignments]
+    (
+        [UserId] ASC
+    )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+
+    ALTER TABLE [dbo].[LineItemAssignments] WITH CHECK ADD CONSTRAINT [FK_LineItemAssignments_LineItems_LineItemId] FOREIGN KEY([LineItemId])
+    REFERENCES [dbo].[LineItems] ([Id])
+    ON DELETE CASCADE
+
+    ALTER TABLE [dbo].[LineItemAssignments] CHECK CONSTRAINT [FK_LineItemAssignments_LineItems_LineItemId]
+
+    ALTER TABLE [dbo].[LineItemAssignments] WITH CHECK ADD CONSTRAINT [FK_LineItemAssignments_Users_UserId] FOREIGN KEY([UserId])
+    REFERENCES [dbo].[Users] ([Id])
+
+    ALTER TABLE [dbo].[LineItemAssignments] CHECK CONSTRAINT [FK_LineItemAssignments_Users_UserId]
+END
+GO

--- a/Migrations/UserDocumentsDb/20260716160723_AddLineItemsAndAssignments.Designer.cs
+++ b/Migrations/UserDocumentsDb/20260716160723_AddLineItemsAndAssignments.Designer.cs
@@ -4,6 +4,7 @@ using Expense.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Expense.API.Migrations.UserDocumentsDb
 {
     [DbContext(typeof(UserDocumentsDbContext))]
-    partial class UserDocumentsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260716160723_AddLineItemsAndAssignments")]
+    partial class AddLineItemsAndAssignments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/UserDocumentsDb/20260716160723_AddLineItemsAndAssignments.cs
+++ b/Migrations/UserDocumentsDb/20260716160723_AddLineItemsAndAssignments.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Expense.API.Migrations.UserDocumentsDb
+{
+    /// <inheritdoc />
+    public partial class AddLineItemsAndAssignments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LineItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DocumentJobResultId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ExpenseId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SortOrder = table.Column<int>(type: "int", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Quantity = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Amount = table.Column<decimal>(type: "decimal(18,2)", nullable: true),
+                    RawFieldsJson = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LineItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LineItems_DocumentJobResults_DocumentJobResultId",
+                        column: x => x.DocumentJobResultId,
+                        principalTable: "DocumentJobResults",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LineItems_Expenses_ExpenseId",
+                        column: x => x.ExpenseId,
+                        principalTable: "Expenses",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LineItemAssignments",
+                columns: table => new
+                {
+                    LineItemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AssignedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LineItemAssignments", x => new { x.LineItemId, x.UserId });
+                    table.ForeignKey(
+                        name: "FK_LineItemAssignments_LineItems_LineItemId",
+                        column: x => x.LineItemId,
+                        principalTable: "LineItems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LineItemAssignments_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LineItemAssignments_UserId",
+                table: "LineItemAssignments",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LineItems_DocumentJobResultId",
+                table: "LineItems",
+                column: "DocumentJobResultId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LineItems_ExpenseId",
+                table: "LineItems",
+                column: "ExpenseId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LineItemAssignments");
+
+            migrationBuilder.DropTable(
+                name: "LineItems");
+        }
+    }
+}

--- a/Models/Domain/Document/LineItem.cs
+++ b/Models/Domain/Document/LineItem.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+
+namespace Expense.API.Models.Domain
+{
+    public class LineItem
+    {
+        public LineItem()
+        {
+        }
+
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Document job result this line item was extracted from.
+        /// </summary>
+        public Guid DocumentJobResultId { get; set; }  // Foreign key for DocumentJobResult
+        public DocumentJobResult DocumentJobResult { get; set; }  // Navigation property
+
+        /// <summary>
+        /// Denormalized so a multi-document expense's items can be queried/aggregated in one
+        /// pass without joining through DocumentJobResult.
+        /// </summary>
+        public Guid ExpenseId { get; set; }  // Foreign key for Expense
+        public Expense Expense { get; set; }  // Navigation property
+
+        /// <summary>
+        /// Position of this item within its document's extracted line item list.
+        /// </summary>
+        public int SortOrder { get; set; }
+
+        public string? Description { get; set; }
+
+        public string? Quantity { get; set; }
+
+        public decimal? Amount { get; set; }
+
+        /// <summary>
+        /// Full raw per-vendor Textract field dump for this row.
+        /// </summary>
+        public string RawFieldsJson { get; set; }
+
+        /// <summary>
+        /// Users assigned to this line item.
+        /// </summary>
+        public ICollection<LineItemAssignment> Assignments { get; set; }
+    }
+}

--- a/Models/Domain/Document/LineItemAssignment.cs
+++ b/Models/Domain/Document/LineItemAssignment.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Expense.API.Models.Domain
+{
+    public class LineItemAssignment
+    {
+        public LineItemAssignment()
+        {
+        }
+
+        /// <summary>
+        /// Foreign key for the associated LineItem. Part of the composite primary key.
+        /// </summary>
+        public Guid LineItemId { get; set; }
+
+        /// <summary>
+        /// Navigation property to the associated LineItem.
+        /// </summary>
+        public LineItem LineItem { get; set; }
+
+        /// <summary>
+        /// Foreign key for the associated User. Part of the composite primary key.
+        /// </summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// Navigation property to the associated User.
+        /// </summary>
+        public User User { get; set; }
+
+        public DateTime AssignedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Models/Domain/Expense/ExpenseDocumentResult.cs
+++ b/Models/Domain/Expense/ExpenseDocumentResult.cs
@@ -4,12 +4,12 @@
     {
         public string DocumentName { get; set; }
         public List<ExpenseSummaryField> SummaryFields { get; set; }
-        public List<LineItem> LineItems { get; set; }
+        public List<TextractLineItemFields> LineItems { get; set; }
 
         public ExpenseDocumentResult()
         {
             SummaryFields = new List<ExpenseSummaryField>();
-            LineItems = new List<LineItem>();
+            LineItems = new List<TextractLineItemFields>();
         }
     }
 
@@ -19,7 +19,7 @@
         public string? FieldValue { get; set; }
     }
 
-    public class LineItem
+    public class TextractLineItemFields
     {
         public string? Description { get; set; }
         public string? Quantity { get; set; }

--- a/Repositories/ExpenseAnalysis/ExpenseAnalysis.cs
+++ b/Repositories/ExpenseAnalysis/ExpenseAnalysis.cs
@@ -275,7 +275,7 @@ namespace Expense.API.Repositories.ExpenseAnalysis
                     expenseDoc.LineItems = response.ExpenseDocuments
                         .SelectMany(expDoc => expDoc.LineItemGroups)
                         .SelectMany(group => group.LineItems)
-                        .Select(item => new Models.Domain.LineItem
+                        .Select(item => new Models.Domain.TextractLineItemFields
                         {
                             Description = item.LineItemExpenseFields
                                             .FirstOrDefault(f => f.Type.Text == "ITEM")?.ValueDetection?.Text,

--- a/docs/ROUTINES_PLAN.md
+++ b/docs/ROUTINES_PLAN.md
@@ -191,7 +191,7 @@ PUT  /api/Expense/{id}/updateShares            line-item assignment — use the 
 - [x] **B5 — Budget threshold alerts**
 - [x] **B6 — Expose `userId` on `GET /api/Friends/getFriends`**
 - [x] **B7 — Require friendship before adding a user to an expense split**
-- [ ] **B8 — LineItem/LineItemAssignment schema**
+- [x] **B8 — LineItem/LineItemAssignment schema**
 - [ ] **B9 — Line-item assignment repository, business rules, StoreResults integration**
 - [ ] **B10 — Controller endpoints + guard old manual-share endpoints**
 


### PR DESCRIPTION
## What was built

Phase B8 from `docs/ROUTINES_PLAN.md` — the normalized, assignable schema layer underneath `DocumentJobResult.ResultLineItems` (the raw dynamic-column JSON blob, left untouched). No behavior change; this is schema-only, per spec.

- **`Models/Domain/Document/LineItem.cs`** — new entity: `Id`, `DocumentJobResultId` + nav, `ExpenseId` + nav (denormalized so a multi-document expense's items can be aggregated without joining through `DocumentJobResult`), `SortOrder`, `Description`, `Quantity`, `Amount`, `RawFieldsJson`.
- **`Models/Domain/Document/LineItemAssignment.cs`** — join entity, composite PK `(LineItemId, UserId)`, `LineItem` nav (FK cascade), `User` nav (FK restrict, same pattern as `Settlement`/`Budget`'s `User` FKs), `AssignedAt` (default `UtcNow`).
- **Naming collision fix**: renamed the pre-existing transient `Models.Domain.LineItem` POCO (used only in `ExpenseAnalysis.StartExpenseExtractAsync` to shape the ad-hoc Textract response) to `TextractLineItemFields`, and updated `ExpenseDocumentResult.LineItems`'s declared type to match. This was the only reference in the codebase.
- **`Data/UserDocumentsDbContext.cs`**: added `DbSet<LineItem>` / `DbSet<LineItemAssignment>`; configured `LineItemAssignment`'s composite key + both FKs (mirroring the existing `ExpenseUser` block) and `LineItem`'s FK to `DocumentJobResult` (cascade) and to `Expense` (restrict, same style as `ExpenseModel.CreatedBy`'s FK).
- **EF migration** `Migrations/UserDocumentsDb/20260716160723_AddLineItemsAndAssignments.cs` (generated via `dotnet ef migrations add AddLineItemsAndAssignments --context UserDocumentsDbContext`), with indexes on `LineItems.DocumentJobResultId`, `LineItems.ExpenseId`, and `LineItemAssignments.UserId`.
- **Hand-written SQL script** `ExpenseAnalyserDbScripts/15-line-items-and-assignments.sql`, following `12-friend-requests.sql`'s idempotent `IF NOT EXISTS` two-table style.
- Ticked B8's checkbox in `docs/ROUTINES_PLAN.md`.

## How it was tested

- `dotnet build` (full solution, `ExpenseApi.sln`) — **0 errors**, only pre-existing warnings (nullable-reference warnings, decimal-precision advisories, EOL-TFM/NuGet-vulnerability advisories already present before this change).
- `dotnet test Tests/Expense.API.IntegrationTests` — **not run**. Docker daemon came up fine in this sandbox, but pulling the required Testcontainers image failed with a genuine network-policy block:
  ```
  $ docker pull testcontainers/ryuk:0.6.0
  unknown: failed to copy: httpReadSeeker: failed open: unexpected status from GET request to
  https://production.cloudfront.docker.com/registry-v2/docker/registry/v2/blobs/... : 403 Forbidden
  ```
  Per the runner protocol this is the documented skip condition. GitHub Actions (`.github/workflows/integration-tests.yml`) will run the full suite on this PR regardless — that's the gate of record.
- No new tests added: per spec, "Tests: none beyond confirming `dotnet build` and the full existing suite still pass unmodified (schema-only phase)". Confirmed the test host's `UserDocumentsDbContext` is provisioned via `EnsureCreatedAsync()` (not migrations), so it builds the new tables straight from the updated model/`OnModelCreating` — no test-infrastructure changes needed for the new tables to come up cleanly. The generic `RestrictCascadeModelCustomizer` (downgrades every FK to `Restrict` at test-schema-creation time) already covers the two new FK pairs without changes.

## Deviations from spec

None. Implemented exactly as specified — no repository/controller/DTO behavior changed, `ExpenseAnalysis.StoreResults` untouched beyond the rename fix-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017r1c7ujNkETFY2TedDMhKq)_