### PR TITLE
routine(B9): Line-item assignment repository, business rules, StoreResults integration

### DIFF
--- a/Data/UserDocumentsDbContext.cs
+++ b/Data/UserDocumentsDbContext.cs
@@ -91,7 +91,7 @@ namespace Expense.API.Data
 
             modelBuilder.Entity<LineItem>()
                 .HasOne(li => li.DocumentJobResult)
-                .WithMany()
+                .WithMany(djr => djr.LineItems)
                 .HasForeignKey(li => li.DocumentJobResultId)
                 .OnDelete(DeleteBehavior.Cascade);
 

--- a/Mappings/AutomapperProfiles.cs
+++ b/Mappings/AutomapperProfiles.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text.Json;
 using AutoMapper;
 using Expense.API.Models.Domain;
@@ -26,7 +27,11 @@ namespace Expense.API.Mappings
                 .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id.ToString()))
                 .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.FileName.ToString()))
                 .ForMember(dest => dest.Url, opt => opt.MapFrom(src => src.S3Url.ToString()));
-            CreateMap<DocumentJobResult, DocumentResultDto>();
+            CreateMap<DocumentJobResult, DocumentResultDto>()
+                .ForMember(dest => dest.LineItems, opt => opt.MapFrom(src => src.LineItems));
+            CreateMap<LineItem, LineItemDto>()
+                .ForMember(dest => dest.Assignees, opt => opt.MapFrom(src => src.Assignments.Select(a => a.User)));
+            CreateMap<User, LineItemAssigneeDto>();
             CreateMap<Notification, NotificationDto>();
             CreateMap<ExpenseUser, ExpenseUserDto>()
                 .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.User.Username))

--- a/Migrations/UserDocumentsDb/UserDocumentsDbContextModelSnapshot.cs
+++ b/Migrations/UserDocumentsDb/UserDocumentsDbContextModelSnapshot.cs
@@ -500,7 +500,7 @@ namespace Expense.API.Migrations.UserDocumentsDb
             modelBuilder.Entity("Expense.API.Models.Domain.LineItem", b =>
                 {
                     b.HasOne("Expense.API.Models.Domain.DocumentJobResult", "DocumentJobResult")
-                        .WithMany()
+                        .WithMany("LineItems")
                         .HasForeignKey("DocumentJobResultId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -563,6 +563,11 @@ namespace Expense.API.Migrations.UserDocumentsDb
                     b.Navigation("Payee");
 
                     b.Navigation("Payer");
+                });
+
+            modelBuilder.Entity("Expense.API.Models.Domain.DocumentJobResult", b =>
+                {
+                    b.Navigation("LineItems");
                 });
 
             modelBuilder.Entity("Expense.API.Models.Domain.Expense", b =>

--- a/Models/DTO/DocumentResultDto.cs
+++ b/Models/DTO/DocumentResultDto.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 namespace Expense.API.Models.DTO
 {
 	public class DocumentResultDto
@@ -7,6 +8,11 @@ namespace Expense.API.Models.DTO
 		{
 		}
         public Guid Id { get; set; }
+
+        /// <summary>
+        /// Normalized, assignable line items derived from this document's scan.
+        /// </summary>
+        public List<LineItemDto> LineItems { get; set; } = new();
 
         /// <summary>
         /// Store total extracted from documents from summaryFields

--- a/Models/DTO/LineItemAssigneeDto.cs
+++ b/Models/DTO/LineItemAssigneeDto.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Expense.API.Models.DTO
+{
+    public class LineItemAssigneeDto
+    {
+        public Guid UserId { get; set; }
+
+        public string UserName { get; set; }
+    }
+}

--- a/Models/DTO/LineItemDto.cs
+++ b/Models/DTO/LineItemDto.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace Expense.API.Models.DTO
+{
+    public class LineItemDto
+    {
+        public Guid Id { get; set; }
+
+        public string? Description { get; set; }
+
+        public string? Quantity { get; set; }
+
+        public decimal? Amount { get; set; }
+
+        public int SortOrder { get; set; }
+
+        public List<LineItemAssigneeDto> Assignees { get; set; } = new();
+    }
+}

--- a/Models/Domain/Document/DocumentJobResult.cs
+++ b/Models/Domain/Document/DocumentJobResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Expense.API.Models.Domain
 {
@@ -66,5 +67,10 @@ namespace Expense.API.Models.Domain
         /// JSON representing summaryFields from expenseDocuments
         /// </summary>
         public string? SummaryFields { get; set; }
+
+        /// <summary>
+        /// Line items extracted from this document job result.
+        /// </summary>
+        public ICollection<LineItem> LineItems { get; set; } = new List<LineItem>();
     }
 }

--- a/Repositories/Expense/ExpenseRepository.cs
+++ b/Repositories/Expense/ExpenseRepository.cs
@@ -794,6 +794,187 @@ namespace Expense.API.Repositories.Expense
                 await textractNotification.Clients.User(user.Username).SendAsync("TextractNotification", message);
             }
         }
+
+        // ----- Line-item assignment -----
+
+        /// <summary>
+        /// Throws when userId isn't the caller and has no accepted FriendRequest with the caller (same
+        /// predicate as CreateExpenseUserAsync's inline friendship check).
+        /// </summary>
+        private async Task EnsureFriendsWithCallerAsync(Guid callerId, Guid userId)
+        {
+            if (userId == callerId)
+            {
+                return;
+            }
+
+            var areFriends = await userDocumentsDbContext.FriendRequests.AnyAsync(
+                fr => ((fr.SentByUserId == callerId && fr.SentToUserId == userId)
+                       || (fr.SentByUserId == userId && fr.SentToUserId == callerId))
+                      && fr.IsAccepted == 1);
+
+            if (!areFriends)
+            {
+                throw new Exception("Users must be friends before sharing an expense.");
+            }
+        }
+
+        private Task<LineItem> GetLineItemWithAssigneesAsync(Guid lineItemId)
+        {
+            return userDocumentsDbContext.LineItems
+                .Include(li => li.Assignments).ThenInclude(a => a.User)
+                .FirstAsync(li => li.Id == lineItemId);
+        }
+
+        public async Task<LineItem> AssignUserToLineItemAsync(Guid lineItemId, Guid userId)
+        {
+            var lineItem = await userDocumentsDbContext.LineItems
+                .Include(li => li.Assignments)
+                .FirstOrDefaultAsync(li => li.Id == lineItemId);
+            if (lineItem == null)
+            {
+                throw new Exception("Line item not found.");
+            }
+
+            var currentUser = await GetCurrentUserAsync();
+            await EnsureFriendsWithCallerAsync(currentUser.Id, userId);
+
+            if (!lineItem.Assignments.Any(a => a.UserId == userId))
+            {
+                await userDocumentsDbContext.LineItemAssignments.AddAsync(new LineItemAssignment
+                {
+                    LineItemId = lineItemId,
+                    UserId = userId
+                });
+                await userDocumentsDbContext.SaveChangesAsync();
+                await RecomputeExpenseUsersFromAssignmentsAsync(lineItem.ExpenseId);
+            }
+
+            return await GetLineItemWithAssigneesAsync(lineItemId);
+        }
+
+        public async Task<LineItem> RemoveUserFromLineItemAsync(Guid lineItemId, Guid userId)
+        {
+            var lineItem = await userDocumentsDbContext.LineItems
+                .Include(li => li.Assignments)
+                .FirstOrDefaultAsync(li => li.Id == lineItemId);
+            if (lineItem == null)
+            {
+                throw new Exception("Line item not found.");
+            }
+
+            var assignment = lineItem.Assignments.FirstOrDefault(a => a.UserId == userId);
+            if (assignment == null)
+            {
+                throw new Exception("User is not assigned to this line item.");
+            }
+
+            if (lineItem.Assignments.Count <= 1)
+            {
+                throw new Exception("Cannot remove the last remaining assignee from a line item.");
+            }
+
+            userDocumentsDbContext.LineItemAssignments.Remove(assignment);
+            await userDocumentsDbContext.SaveChangesAsync();
+            await RecomputeExpenseUsersFromAssignmentsAsync(lineItem.ExpenseId);
+
+            return await GetLineItemWithAssigneesAsync(lineItemId);
+        }
+
+        public async Task<List<LineItem>> AssignUserToAllLineItemsAsync(Guid expenseId, Guid userId)
+        {
+            var lineItems = await userDocumentsDbContext.LineItems
+                .Where(li => li.ExpenseId == expenseId)
+                .Include(li => li.Assignments)
+                .ToListAsync();
+
+            var currentUser = await GetCurrentUserAsync();
+            await EnsureFriendsWithCallerAsync(currentUser.Id, userId);
+
+            var itemsMissingUser = lineItems.Where(li => !li.Assignments.Any(a => a.UserId == userId)).ToList();
+            if (itemsMissingUser.Count > 0)
+            {
+                foreach (var lineItem in itemsMissingUser)
+                {
+                    await userDocumentsDbContext.LineItemAssignments.AddAsync(new LineItemAssignment
+                    {
+                        LineItemId = lineItem.Id,
+                        UserId = userId
+                    });
+                }
+                await userDocumentsDbContext.SaveChangesAsync();
+                await RecomputeExpenseUsersFromAssignmentsAsync(expenseId);
+            }
+
+            return await userDocumentsDbContext.LineItems
+                .Where(li => li.ExpenseId == expenseId)
+                .Include(li => li.Assignments).ThenInclude(a => a.User)
+                .ToListAsync();
+        }
+
+        public async Task RecomputeExpenseUsersFromAssignmentsAsync(Guid expenseId)
+        {
+            var expense = await userDocumentsDbContext.Expenses.FirstOrDefaultAsync(e => e.Id == expenseId);
+            if (expense == null)
+            {
+                return;
+            }
+
+            var lineItems = await userDocumentsDbContext.LineItems
+                .Where(li => li.ExpenseId == expenseId)
+                .Include(li => li.Assignments)
+                .ToListAsync();
+
+            // Per-person totals: sum of that person's even split across every line item they're on. Any
+            // remainder between expense.Amount and the itemized sum (tax/tip/manual top-ups) is left
+            // unassigned, never redistributed.
+            var perUserDollar = new Dictionary<Guid, double>();
+            foreach (var lineItem in lineItems)
+            {
+                if (lineItem.Amount == null || lineItem.Assignments == null || lineItem.Assignments.Count == 0)
+                {
+                    continue;
+                }
+
+                var perAssigneeShare = (double)lineItem.Amount.Value / lineItem.Assignments.Count;
+                foreach (var assignment in lineItem.Assignments)
+                {
+                    perUserDollar[assignment.UserId] = perUserDollar.GetValueOrDefault(assignment.UserId) + perAssigneeShare;
+                }
+            }
+
+            var existingExpenseUsers = await userDocumentsDbContext.ExpenseUsers
+                .Where(eu => eu.ExpenseId == expenseId)
+                .ToListAsync();
+
+            foreach (var (assignedUserId, dollarAmount) in perUserDollar)
+            {
+                var userAmount = Math.Round(dollarAmount, 2);
+                var userShare = expense.Amount > 0 ? dollarAmount / (double)expense.Amount : 0;
+
+                var existingExpenseUser = existingExpenseUsers.FirstOrDefault(eu => eu.UserId == assignedUserId);
+                if (existingExpenseUser != null)
+                {
+                    existingExpenseUser.UserAmount = userAmount;
+                    existingExpenseUser.UserShare = userShare;
+                }
+                else
+                {
+                    await userDocumentsDbContext.ExpenseUsers.AddAsync(
+                        new ExpenseUser(expenseId, assignedUserId, userAmount) { UserShare = userShare });
+                }
+            }
+
+            var expenseUsersToRemove = existingExpenseUsers
+                .Where(eu => !perUserDollar.ContainsKey(eu.UserId))
+                .ToList();
+            if (expenseUsersToRemove.Count > 0)
+            {
+                userDocumentsDbContext.ExpenseUsers.RemoveRange(expenseUsersToRemove);
+            }
+
+            await userDocumentsDbContext.SaveChangesAsync();
+        }
     }
 }
 

--- a/Repositories/Expense/IExpenseRepository.cs
+++ b/Repositories/Expense/IExpenseRepository.cs
@@ -135,6 +135,32 @@ namespace Expense.API.Repositories.Expense
         /// </summary>
         public Task<BalanceDetailDto?> GetBalanceDetailAsync(Guid counterpartyId);
 
+        /// <summary>
+        /// Assign a user to a line item (friendship-gated, same as CreateExpenseUserAsync). No-op if
+        /// already assigned. Recomputes the expense's ExpenseUser shares from all assignments.
+        /// </summary>
+        public Task<LineItem> AssignUserToLineItemAsync(Guid lineItemId, Guid userId);
+
+        /// <summary>
+        /// Remove a user from a line item. Throws when this would leave zero assignees. Recomputes the
+        /// expense's ExpenseUser shares from all assignments.
+        /// </summary>
+        public Task<LineItem> RemoveUserFromLineItemAsync(Guid lineItemId, Guid userId);
+
+        /// <summary>
+        /// Additively assign a user to every line item on an expense that they aren't already on
+        /// (friendship-gated). Never removes existing assignees. Recomputes the expense's ExpenseUser
+        /// shares from all assignments.
+        /// </summary>
+        public Task<List<LineItem>> AssignUserToAllLineItemsAsync(Guid expenseId, Guid userId);
+
+        /// <summary>
+        /// Rebuild the expense's ExpenseUser rows (the materialized read model used by balances/dashboard)
+        /// from its current LineItemAssignments: each user's UserAmount is the sum of their even split
+        /// across every line item they're on, with no redistribution of any unassigned remainder.
+        /// </summary>
+        public Task RecomputeExpenseUsersFromAssignmentsAsync(Guid expenseId);
+
     }
 }
 

--- a/Repositories/ExpenseAnalysis/ExpenseAnalysis.cs
+++ b/Repositories/ExpenseAnalysis/ExpenseAnalysis.cs
@@ -9,6 +9,7 @@ using Amazon.Textract.Model;
 using Azure;
 using Expense.API.Data;
 using Expense.API.Models.Domain;
+using Expense.API.Repositories.Expense;
 using Expense.API.Repositories.Notifications;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
@@ -29,10 +30,12 @@ namespace Expense.API.Repositories.ExpenseAnalysis
         private readonly IAmazonTextract amazonTextract;
         private readonly IHubContext<TextractNotificationHub> textractNotification;
         private readonly ITextractNotification textractNotificationDb;
+        private readonly IExpenseRepository expenseRepository;
 
         public ExpenseAnalysis(IConfiguration configuration, IAmazonS3 amazonS3, IHttpContextAccessor httpContextAccessor
             , UserDocumentsDbContext userDocumentsDbContext, IAmazonTextract amazonTextract,
-                IHubContext<TextractNotificationHub> textractNotification, ITextractNotification textractNotificationDb)
+                IHubContext<TextractNotificationHub> textractNotification, ITextractNotification textractNotificationDb,
+                IExpenseRepository expenseRepository)
         {
             this.configuration = configuration;
             this.s3Client = amazonS3;
@@ -41,6 +44,7 @@ namespace Expense.API.Repositories.ExpenseAnalysis
             this.amazonTextract = amazonTextract;
             this.textractNotification = textractNotification;
             this.textractNotificationDb = textractNotificationDb;
+            this.expenseRepository = expenseRepository;
         }
 
         private string? BuildColumnJson(LineItemFields lineItem)
@@ -171,6 +175,75 @@ namespace Expense.API.Repositories.ExpenseAnalysis
 
         }
 
+        /// <summary>
+        /// Persist one LineItem row per Textract-extracted line item on this document (the normalized,
+        /// assignable layer underneath ResultLineItems' raw JSON blob, which is left untouched). Each new
+        /// item's initial assignees carry forward from the expense's existing ExpenseUser rows (manual
+        /// adds, or a prior scan's assignments) or default to the document's creator when none exist yet.
+        /// </summary>
+        private async Task PersistLineItemsAsync(DocumentJobResult documentJobResult, List<ExpenseDocument> expenseDocuments)
+        {
+            var existingAssigneeIds = await userDocumentsDbContext.ExpenseUsers
+                .Where(eu => eu.ExpenseId == documentJobResult.ExpenseId)
+                .Select(eu => eu.UserId)
+                .ToListAsync();
+            var defaultAssigneeIds = existingAssigneeIds.Count > 0
+                ? existingAssigneeIds
+                : new List<Guid> { documentJobResult.CreatedById };
+
+            var sortOrder = 0;
+            foreach (var expenseDocument in expenseDocuments)
+            {
+                foreach (var lineItemGroup in expenseDocument.LineItemGroups)
+                {
+                    foreach (var lineItem in lineItemGroup.LineItems)
+                    {
+                        var rawFields = new Dictionary<string, string>();
+                        foreach (var field in lineItem.LineItemExpenseFields)
+                        {
+                            if (!string.IsNullOrEmpty(field.Type?.Text) && !string.IsNullOrEmpty(field.ValueDetection?.Text))
+                            {
+                                rawFields[field.Type.Text] = field.ValueDetection.Text;
+                            }
+                        }
+
+                        decimal? amount = null;
+                        if (rawFields.TryGetValue("PRICE", out var priceValue)
+                            && decimal.TryParse(Regex.Replace(priceValue, @"[^\d.-]", ""), out var parsedAmount))
+                        {
+                            amount = parsedAmount;
+                        }
+
+                        var newLineItem = new LineItem
+                        {
+                            Id = Guid.NewGuid(),
+                            DocumentJobResultId = documentJobResult.Id,
+                            ExpenseId = documentJobResult.ExpenseId,
+                            SortOrder = sortOrder,
+                            Description = rawFields.TryGetValue("ITEM", out var description) ? description : null,
+                            Quantity = rawFields.TryGetValue("PRODUCT_CODE", out var quantity) ? quantity : null,
+                            Amount = amount,
+                            RawFieldsJson = JsonConvert.SerializeObject(rawFields, Formatting.Indented)
+                        };
+                        await userDocumentsDbContext.LineItems.AddAsync(newLineItem);
+
+                        foreach (var assigneeId in defaultAssigneeIds)
+                        {
+                            await userDocumentsDbContext.LineItemAssignments.AddAsync(new LineItemAssignment
+                            {
+                                LineItemId = newLineItem.Id,
+                                UserId = assigneeId
+                            });
+                        }
+
+                        sortOrder++;
+                    }
+                }
+            }
+
+            await userDocumentsDbContext.SaveChangesAsync();
+        }
+
         public async Task StoreResults(GetExpenseAnalysisResponse getExpenseAnalysisResponse, DocumentJobResult documentJobResult, byte status)
         {
             documentJobResult.ResultCreatedAt = DateTime.UtcNow;
@@ -178,6 +251,7 @@ namespace Expense.API.Repositories.ExpenseAnalysis
             {
                 documentJobResult.ColumnNames = BuildColumnJson(getExpenseAnalysisResponse.ExpenseDocuments[0].LineItemGroups[0].LineItems[0]);
                 documentJobResult.ResultLineItems = BuildLineItemJson(getExpenseAnalysisResponse.ExpenseDocuments);
+                await PersistLineItemsAsync(documentJobResult, getExpenseAnalysisResponse.ExpenseDocuments);
             }
             documentJobResult.SummaryFields = BuildSummaryFieldsJson(getExpenseAnalysisResponse.ExpenseDocuments[0]);
             documentJobResult.Status = status;
@@ -189,7 +263,15 @@ namespace Expense.API.Repositories.ExpenseAnalysis
 
                 await UpdateTotal(documentJobResult.ExpenseId, summaryFieldsList);
             }
-            await UpdateExpenseUsers(documentJobResult.ExpenseId);
+
+            if (await userDocumentsDbContext.LineItems.AnyAsync(li => li.ExpenseId == documentJobResult.ExpenseId))
+            {
+                await expenseRepository.RecomputeExpenseUsersFromAssignmentsAsync(documentJobResult.ExpenseId);
+            }
+            else
+            {
+                await UpdateExpenseUsers(documentJobResult.ExpenseId);
+            }
             //await userDocumentsDbContext.DocumentJobResults.Up(result);
             await userDocumentsDbContext.SaveChangesAsync();
 

--- a/Tests/Expense.API.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/Tests/Expense.API.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -1,8 +1,11 @@
 using System.Net.Http.Json;
+using System.Security.Claims;
 using Expense.API.Data;
 using Expense.API.Models.Domain;
 using Expense.API.Models.DTO;
+using Expense.API.Repositories.Expense;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -85,6 +88,27 @@ public abstract class IntegrationTestBase
             await db.SaveChangesAsync();
         });
         return user;
+    }
+
+    /// <summary>
+    /// Runs an action against a scoped IExpenseRepository as if `caller` were the authenticated user
+    /// (NameIdentifier claim = caller's username, the same claim repository methods resolve the current
+    /// user from). For repository methods with no HTTP endpoint yet to drive them through.
+    /// </summary>
+    protected async Task<T> WithExpenseRepositoryAsync<T>(TestUser caller, Func<IExpenseRepository, Task<T>> action)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var httpContextAccessor = scope.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, caller.UserName)
+            }))
+        };
+
+        var repository = scope.ServiceProvider.GetRequiredService<IExpenseRepository>();
+        return await action(repository);
     }
 
     /// <summary>Sends a friend request from sender to recipient through the real API and accepts it.</summary>

--- a/Tests/Expense.API.IntegrationTests/Infrastructure/SeedData.cs
+++ b/Tests/Expense.API.IntegrationTests/Infrastructure/SeedData.cs
@@ -72,4 +72,28 @@ public static class SeedData
         db.DocumentJobResults.Add(jobResult);
         return jobResult;
     }
+
+    /// <summary>A normalized, assignable line item with its initial assignees.</summary>
+    public static LineItem AddLineItem(UserDocumentsDbContext db, Guid expenseId, Guid documentJobResultId,
+        string description, decimal amount, params Guid[] assigneeUserIds)
+    {
+        var lineItem = new LineItem
+        {
+            Id = Guid.NewGuid(),
+            DocumentJobResultId = documentJobResultId,
+            ExpenseId = expenseId,
+            SortOrder = 0,
+            Description = description,
+            Amount = amount,
+            RawFieldsJson = "{}"
+        };
+        db.LineItems.Add(lineItem);
+
+        foreach (var userId in assigneeUserIds)
+        {
+            db.LineItemAssignments.Add(new LineItemAssignment { LineItemId = lineItem.Id, UserId = userId });
+        }
+
+        return lineItem;
+    }
 }

--- a/Tests/Expense.API.IntegrationTests/LineItemAssignmentTests.cs
+++ b/Tests/Expense.API.IntegrationTests/LineItemAssignmentTests.cs
@@ -1,0 +1,339 @@
+using System.Linq;
+using Amazon.Textract;
+using Amazon.Textract.Model;
+using Expense.API.Data;
+using Expense.API.IntegrationTests.Infrastructure;
+using Expense.API.Repositories.ExpenseAnalysis;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+/// <summary>
+/// Exercises the line-item assignment business rules directly against IExpenseRepository (there is no
+/// HTTP surface yet - that's phase B10): friendship-gated assign/remove, additive bulk-assign, and the
+/// ExpenseUser recompute that derives per-person totals from assignments. Also exercises
+/// ExpenseAnalysis.StoreResults' first-scan carry-forward of existing ExpenseUser rows onto new
+/// LineItems.
+/// </summary>
+public class LineItemAssignmentTests : IntegrationTestBase
+{
+    public LineItemAssignmentTests(CustomWebAppFactory factory) : base(factory) { }
+
+    private static LineItemFields BuildLineItemFields(string item, string price)
+    {
+        return new LineItemFields
+        {
+            LineItemExpenseFields = new List<ExpenseField>
+            {
+                new ExpenseField { Type = new ExpenseType { Text = "ITEM" }, ValueDetection = new ExpenseDetection { Text = item } },
+                new ExpenseField { Type = new ExpenseType { Text = "PRICE" }, ValueDetection = new ExpenseDetection { Text = price } }
+            }
+        };
+    }
+
+    [Fact]
+    public async Task AssignUserToLineItem_with_a_non_friend_throws_the_expected_message()
+    {
+        var owner = await RegisterAndLoginAsync("liaowner");
+        var stranger = await RegisterAndLoginAsync("liastranger");
+
+        Guid itemId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Dinner", 10m, "Dining", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 10m);
+            var item = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Pasta", 10m, owner.Id);
+            await db.SaveChangesAsync();
+            itemId = item.Id;
+        });
+
+        Func<Task> act = () => WithExpenseRepositoryAsync(owner, repo => repo.AssignUserToLineItemAsync(itemId, stranger.Id));
+
+        await act.Should().ThrowAsync<Exception>().WithMessage("Users must be friends before sharing an expense.");
+    }
+
+    [Fact]
+    public async Task AssignUserToLineItem_with_an_accepted_friend_recomputes_an_even_split_across_line_items()
+    {
+        var owner = await RegisterAndLoginAsync("liaowner");
+        var friend = await RegisterAndLoginAsync("liafriend");
+        await BefriendAsync(owner, friend);
+
+        Guid expenseId = Guid.Empty, item1Id = Guid.Empty, item2Id = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Grocery run", 60m, "Groceries", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 60m);
+            var item1 = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Milk", 30m, owner.Id);
+            var item2 = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Bread", 30m, owner.Id);
+            SeedData.AddShare(db, expense.Id, owner.Id, 60, 1.0); // creator's own row, as CreateExpenseAsync would seed it
+            await db.SaveChangesAsync();
+            expenseId = expense.Id;
+            item1Id = item1.Id;
+            item2Id = item2.Id;
+        });
+
+        await WithExpenseRepositoryAsync(owner, repo => repo.AssignUserToLineItemAsync(item1Id, friend.Id));
+        var updatedItem2 = await WithExpenseRepositoryAsync(owner, repo => repo.AssignUserToLineItemAsync(item2Id, friend.Id));
+
+        updatedItem2.Assignments.Select(a => a.UserId).Should().BeEquivalentTo(new[] { owner.Id, friend.Id });
+
+        await WithDbAsync(async db =>
+        {
+            var expenseUsers = await db.ExpenseUsers.Where(eu => eu.ExpenseId == expenseId).ToListAsync();
+            expenseUsers.Should().HaveCount(2);
+            expenseUsers.First(eu => eu.UserId == owner.Id).UserAmount.Should().Be(30.0);
+            expenseUsers.First(eu => eu.UserId == friend.Id).UserAmount.Should().Be(30.0);
+        });
+    }
+
+    [Fact]
+    public async Task AssignUserToLineItem_that_is_already_assigned_is_a_no_op()
+    {
+        var owner = await RegisterAndLoginAsync("liaowner");
+
+        Guid itemId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Dinner", 10m, "Dining", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 10m);
+            var item = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Pasta", 10m, owner.Id);
+            await db.SaveChangesAsync();
+            itemId = item.Id;
+        });
+
+        var result = await WithExpenseRepositoryAsync(owner, repo => repo.AssignUserToLineItemAsync(itemId, owner.Id));
+
+        result.Assignments.Should().ContainSingle(a => a.UserId == owner.Id);
+    }
+
+    [Fact]
+    public async Task RemoveUserFromLineItem_last_remaining_assignee_throws_the_expected_message()
+    {
+        var owner = await RegisterAndLoginAsync("liaowner");
+
+        Guid itemId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Snack", 10m, "Dining", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 10m);
+            var item = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Chips", 10m, owner.Id);
+            await db.SaveChangesAsync();
+            itemId = item.Id;
+        });
+
+        Func<Task> act = () => WithExpenseRepositoryAsync(owner, repo => repo.RemoveUserFromLineItemAsync(itemId, owner.Id));
+
+        await act.Should().ThrowAsync<Exception>().WithMessage("Cannot remove the last remaining assignee from a line item.");
+    }
+
+    [Fact]
+    public async Task RemoveUserFromLineItem_with_more_than_one_assignee_recomputes_shares()
+    {
+        var owner = await RegisterAndLoginAsync("liaowner");
+        var friend = await RegisterAndLoginAsync("liafriend");
+        await BefriendAsync(owner, friend);
+
+        Guid expenseId = Guid.Empty, itemId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Lunch", 20m, "Dining", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 20m);
+            var item = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Sandwich", 20m, owner.Id, friend.Id);
+            SeedData.AddShare(db, expense.Id, owner.Id, 10, 0.5);
+            SeedData.AddShare(db, expense.Id, friend.Id, 10, 0.5);
+            await db.SaveChangesAsync();
+            expenseId = expense.Id;
+            itemId = item.Id;
+        });
+
+        var updated = await WithExpenseRepositoryAsync(owner, repo => repo.RemoveUserFromLineItemAsync(itemId, friend.Id));
+
+        updated.Assignments.Select(a => a.UserId).Should().BeEquivalentTo(new[] { owner.Id });
+
+        await WithDbAsync(async db =>
+        {
+            var expenseUsers = await db.ExpenseUsers.Where(eu => eu.ExpenseId == expenseId).ToListAsync();
+            expenseUsers.Should().ContainSingle();
+            expenseUsers[0].UserId.Should().Be(owner.Id);
+            expenseUsers[0].UserAmount.Should().Be(20.0);
+        });
+    }
+
+    [Fact]
+    public async Task AssignUserToAllLineItems_is_additive_and_never_removes_other_assignees()
+    {
+        var owner = await RegisterAndLoginAsync("liaowner");
+        var friendA = await RegisterAndLoginAsync("liafrienda");
+        var friendB = await RegisterAndLoginAsync("liafriendb");
+        await BefriendAsync(owner, friendA);
+        await BefriendAsync(owner, friendB);
+
+        Guid expenseId = Guid.Empty, item1Id = Guid.Empty, item2Id = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Groceries", 40m, "Groceries", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 40m);
+            var item1 = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Milk", 20m, owner.Id, friendA.Id);
+            var item2 = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Bread", 20m, owner.Id);
+            await db.SaveChangesAsync();
+            expenseId = expense.Id;
+            item1Id = item1.Id;
+            item2Id = item2.Id;
+        });
+
+        var updatedItems = await WithExpenseRepositoryAsync(owner, repo => repo.AssignUserToAllLineItemsAsync(expenseId, friendB.Id));
+
+        var item1Updated = updatedItems.Single(li => li.Id == item1Id);
+        var item2Updated = updatedItems.Single(li => li.Id == item2Id);
+
+        // Additive: friendA's pre-existing assignment on item1 is untouched, friendB is added to both.
+        item1Updated.Assignments.Select(a => a.UserId).Should().BeEquivalentTo(new[] { owner.Id, friendA.Id, friendB.Id });
+        item2Updated.Assignments.Select(a => a.UserId).Should().BeEquivalentTo(new[] { owner.Id, friendB.Id });
+    }
+
+    [Fact]
+    public async Task AssignUserToAllLineItems_with_a_non_friend_throws_the_expected_message()
+    {
+        var owner = await RegisterAndLoginAsync("liaowner");
+        var stranger = await RegisterAndLoginAsync("liastranger");
+
+        Guid expenseId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Groceries", 20m, "Groceries", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 20m);
+            SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Milk", 20m, owner.Id);
+            await db.SaveChangesAsync();
+            expenseId = expense.Id;
+        });
+
+        Func<Task> act = () => WithExpenseRepositoryAsync(owner, repo => repo.AssignUserToAllLineItemsAsync(expenseId, stranger.Id));
+
+        await act.Should().ThrowAsync<Exception>().WithMessage("Users must be friends before sharing an expense.");
+    }
+
+    [Fact]
+    public async Task StoreResults_first_scan_carries_forward_existing_expense_users_as_line_item_assignees()
+    {
+        var owner = await RegisterAndLoginAsync("liascanowner");
+        var friend = await RegisterAndLoginAsync("liascanfriend");
+        await BefriendAsync(owner, friend);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<UserDocumentsDbContext>();
+        var expenseAnalysis = scope.ServiceProvider.GetRequiredService<IExpenseAnalysis>();
+
+        var expense = SeedData.AddExpense(db, owner.Id, "Dinner", 0m, "Dining", DateTime.UtcNow);
+        var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+        SeedData.AddShare(db, expense.Id, owner.Id, 0, 0.5);
+        SeedData.AddShare(db, expense.Id, friend.Id, 0, 0.5);
+        var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 0m, status: 0);
+        await db.SaveChangesAsync();
+
+        var response = new GetExpenseAnalysisResponse
+        {
+            JobStatus = JobStatus.SUCCEEDED,
+            ExpenseDocuments = new List<ExpenseDocument>
+            {
+                new ExpenseDocument
+                {
+                    SummaryFields = new List<ExpenseField>
+                    {
+                        new ExpenseField
+                        {
+                            Type = new ExpenseType { Text = "TOTAL" },
+                            ValueDetection = new ExpenseDetection { Text = "20.00" }
+                        }
+                    },
+                    LineItemGroups = new List<LineItemGroup>
+                    {
+                        new LineItemGroup
+                        {
+                            LineItems = new List<LineItemFields>
+                            {
+                                BuildLineItemFields("Coffee", "10.00"),
+                                BuildLineItemFields("Bagel", "10.00")
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        await expenseAnalysis.StoreResults(response, jobResult, 1);
+
+        var persistedItems = await db.LineItems
+            .Where(li => li.ExpenseId == expense.Id)
+            .Include(li => li.Assignments)
+            .ToListAsync();
+
+        persistedItems.Should().HaveCount(2);
+        persistedItems.Should().OnlyContain(li =>
+            li.Assignments.Select(a => a.UserId).OrderBy(id => id)
+                .SequenceEqual(new[] { owner.Id, friend.Id }.OrderBy(id => id)));
+
+        var expenseUsers = await db.ExpenseUsers.Where(eu => eu.ExpenseId == expense.Id).ToListAsync();
+        expenseUsers.Should().HaveCount(2);
+        expenseUsers.First(eu => eu.UserId == owner.Id).UserAmount.Should().Be(10.0);
+        expenseUsers.First(eu => eu.UserId == friend.Id).UserAmount.Should().Be(10.0);
+    }
+
+    [Fact]
+    public async Task StoreResults_with_no_pre_existing_expense_users_defaults_new_items_to_the_creator_only()
+    {
+        var owner = await RegisterAndLoginAsync("liascanowner2");
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<UserDocumentsDbContext>();
+        var expenseAnalysis = scope.ServiceProvider.GetRequiredService<IExpenseAnalysis>();
+
+        var expense = SeedData.AddExpense(db, owner.Id, "Coffee run", 0m, "Dining", DateTime.UtcNow);
+        var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+        var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 0m, status: 0);
+        await db.SaveChangesAsync();
+
+        var response = new GetExpenseAnalysisResponse
+        {
+            JobStatus = JobStatus.SUCCEEDED,
+            ExpenseDocuments = new List<ExpenseDocument>
+            {
+                new ExpenseDocument
+                {
+                    SummaryFields = new List<ExpenseField>
+                    {
+                        new ExpenseField
+                        {
+                            Type = new ExpenseType { Text = "TOTAL" },
+                            ValueDetection = new ExpenseDetection { Text = "5.00" }
+                        }
+                    },
+                    LineItemGroups = new List<LineItemGroup>
+                    {
+                        new LineItemGroup
+                        {
+                            LineItems = new List<LineItemFields> { BuildLineItemFields("Latte", "5.00") }
+                        }
+                    }
+                }
+            }
+        };
+
+        await expenseAnalysis.StoreResults(response, jobResult, 1);
+
+        var persistedItem = await db.LineItems
+            .Include(li => li.Assignments)
+            .SingleAsync(li => li.ExpenseId == expense.Id);
+        persistedItem.Assignments.Select(a => a.UserId).Should().BeEquivalentTo(new[] { owner.Id });
+    }
+}

--- a/docs/ROUTINES_PLAN.md
+++ b/docs/ROUTINES_PLAN.md
@@ -192,7 +192,7 @@ PUT  /api/Expense/{id}/updateShares            line-item assignment — use the 
 - [x] **B6 — Expose `userId` on `GET /api/Friends/getFriends`**
 - [x] **B7 — Require friendship before adding a user to an expense split**
 - [x] **B8 — LineItem/LineItemAssignment schema**
-- [ ] **B9 — Line-item assignment repository, business rules, StoreResults integration**
+- [x] **B9 — Line-item assignment repository, business rules, StoreResults integration**
 - [ ] **B10 — Controller endpoints + guard old manual-share endpoints**
 
 ---


### PR DESCRIPTION
## What was built

Phase B9 from `docs/ROUTINES_PLAN.md`: the write path and business rules for line-item assignment (no HTTP endpoints yet — that's B10).

- **`IExpenseRepository` / `ExpenseRepository`** — new methods:
  - `AssignUserToLineItemAsync(lineItemId, userId)` — friendship-gated (same predicate as B7's `CreateExpenseUserAsync`, skipped when assigning yourself), no-op if already assigned, else inserts the assignment and recomputes shares.
  - `RemoveUserFromLineItemAsync(lineItemId, userId)` — throws `"Cannot remove the last remaining assignee from a line item."` when it would leave zero assignees.
  - `AssignUserToAllLineItemsAsync(expenseId, userId)` — one friendship check up front, additive only (never touches other users' assignments on any item).
  - `RecomputeExpenseUsersFromAssignmentsAsync(expenseId)` — upserts `ExpenseUser` rows to exactly the set of users with ≥1 line-item assignment; each user's `UserAmount` is the sum of their even split across every item they're on (`Math.Round(_, 2)`), `UserShare = perUserDollar / expense.Amount`. Any gap between `expense.Amount` and the itemized sum (tax/tip/manual top-ups) is left unassigned, never redistributed, per spec.
- **`ExpenseAnalysis.StoreResults`** — alongside the existing raw `ResultLineItems` JSON blob (untouched), now persists one `LineItem` row per Textract-extracted item (`Description` from `"ITEM"`, `Quantity` from `"PRODUCT_CODE"` matching the existing ad-hoc `TextractLineItemFields` precedent, `Amount` parsed from `"PRICE"` via the same `Regex.Replace(_, @"[^\d.-]", "")` used by `GetTotal`, `RawFieldsJson` = the full per-row field dump). New items' initial assignees carry forward from the expense's existing `ExpenseUser` rows (manual adds or a prior scan), defaulting to the scan's creator only when none exist yet. `StoreResults` now calls `RecomputeExpenseUsersFromAssignmentsAsync` once the expense has any `LineItem`, otherwise keeps the legacy `UpdateExpenseUsers` rescale path — expenses with zero line items are unaffected.
- **DTOs/mapping**: `LineItemDto`, `LineItemAssigneeDto`, `DocumentResultDto.LineItems`, and the AutoMapper maps per the spec (including extending `CreateMap<DocumentJobResult, DocumentResultDto>()`).
- Added `DocumentJobResult.LineItems` navigation collection (wired to the existing B8 FK via `WithMany(djr => djr.LineItems)`) so the AutoMapper map has something to project from — this is a nav-only change with **no schema diff** (verified: `dotnet ef migrations add` produced an empty `Up`/`Down`, so no new migration file was added, only the model snapshot updated).

## Testing

- `dotnet build` (both `Expense.API.csproj` and the whole solution) — **0 errors**, only pre-existing nullable/analyzer warnings.
- `dotnet test Tests/Expense.API.IntegrationTests` — **could not run**: this sandbox's Docker daemon could be started, but pulling the Testcontainers image failed with a policy-denied error from the egress proxy:
  ```
  failed to copy: httpReadSeeker: failed open: failed to do request: Get "https://production.cloudfront.docker.com/registry-v2/...": Forbidden
  ```
  (pulling `testcontainers/ryuk:0.6.0`, which the suite needs). GitHub Actions (`.github/workflows/integration-tests.yml`) runs the full suite on this PR regardless and is the gate of record.
- New suite `Tests/Expense.API.IntegrationTests/LineItemAssignmentTests.cs` covers: non-friend assignment throws the exact message; an accepted friend's assignment recomputes a correct 2-item/2-person even split; assigning an already-assigned user is a no-op; removing the last remaining assignee throws the exact message; removing one of two assignees recomputes shares; bulk-assign is additive (pre-existing assignees on other items untouched) and rejects non-friends; `StoreResults` carry-forward from pre-existing `ExpenseUser` rows onto newly-scanned line items; `StoreResults` defaulting to creator-only when no `ExpenseUser` rows exist yet.
- Since B9 has no HTTP endpoints, tests drive `IExpenseRepository` directly. Added a `WithExpenseRepositoryAsync` helper to `IntegrationTestBase` that fakes the `ClaimTypes.NameIdentifier` claim on a scoped `IHttpContextAccessor.HttpContext`, since `GetCurrentUserAsync()`-based repository methods need an authenticated caller and there's no request pipeline to drive it through yet. Also added `SeedData.AddLineItem(...)` per the spec's exact signature.
- The carry-forward/creator-default tests construct a real `Amazon.Textract.Model.GetExpenseAnalysisResponse` and call `ExpenseAnalysis.StoreResults` directly (via a scoped `IExpenseAnalysis`/`UserDocumentsDbContext` pair) to exercise the actual Textract-parsing + carry-forward logic, not just the recompute math.

## Deviations from spec

- None functionally. The friendship-check logic is duplicated into a new private `EnsureFriendsWithCallerAsync` helper on `ExpenseRepository` rather than extracting `CreateExpenseUserAsync`'s inline check into a shared method — the spec says "copied," and this avoids touching unrelated existing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011DDLzQL1Dn1UeXbj8uM36H)_