### PR TITLE
routine(B10): Controller endpoints + guard old manual-share endpoints

### DIFF
--- a/Controllers/ExpenseController.cs
+++ b/Controllers/ExpenseController.cs
@@ -300,6 +300,57 @@ namespace Expense.API.Controllers
             }
         }
 
+        // PUT api/Expense/lineItem/{lineItemId}/assignees/{userId}
+        [HttpPut]
+        [Route("lineItem/{lineItemId}/assignees/{userId}")]
+        public async Task<IActionResult> PutLineItemAssignee(Guid lineItemId, Guid userId)
+        {
+            try
+            {
+                var result = await expenseRepository.AssignUserToLineItemAsync(lineItemId, userId);
+                var resultDto = mapper.Map<LineItemDto>(result);
+                return Ok(resultDto);
+            }
+            catch (Exception e)
+            {
+                return BadRequest(e.Message);
+            }
+        }
+
+        // DELETE api/Expense/lineItem/{lineItemId}/assignees/{userId}
+        [HttpDelete]
+        [Route("lineItem/{lineItemId}/assignees/{userId}")]
+        public async Task<IActionResult> DeleteLineItemAssignee(Guid lineItemId, Guid userId)
+        {
+            try
+            {
+                var result = await expenseRepository.RemoveUserFromLineItemAsync(lineItemId, userId);
+                var resultDto = mapper.Map<LineItemDto>(result);
+                return Ok(resultDto);
+            }
+            catch (Exception e)
+            {
+                return BadRequest(e.Message);
+            }
+        }
+
+        // PUT api/Expense/{expenseId}/lineItems/assignAll/{userId}
+        [HttpPut]
+        [Route("{expenseId}/lineItems/assignAll/{userId}")]
+        public async Task<IActionResult> PutAssignAllLineItems(Guid expenseId, Guid userId)
+        {
+            try
+            {
+                var result = await expenseRepository.AssignUserToAllLineItemsAsync(expenseId, userId);
+                var resultDto = mapper.Map<List<LineItemDto>>(result);
+                return Ok(resultDto);
+            }
+            catch (Exception e)
+            {
+                return BadRequest(e.Message);
+            }
+        }
+
         // PUT api/values/5
         [HttpPut]
         [Route("{id}")]

--- a/Mappings/AutomapperProfiles.cs
+++ b/Mappings/AutomapperProfiles.cs
@@ -31,7 +31,8 @@ namespace Expense.API.Mappings
                 .ForMember(dest => dest.LineItems, opt => opt.MapFrom(src => src.LineItems));
             CreateMap<LineItem, LineItemDto>()
                 .ForMember(dest => dest.Assignees, opt => opt.MapFrom(src => src.Assignments.Select(a => a.User)));
-            CreateMap<User, LineItemAssigneeDto>();
+            CreateMap<User, LineItemAssigneeDto>()
+                .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.Id));
             CreateMap<Notification, NotificationDto>();
             CreateMap<ExpenseUser, ExpenseUserDto>()
                 .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.User.Username))

--- a/Models/DTO/ExpenseUserDto.cs
+++ b/Models/DTO/ExpenseUserDto.cs
@@ -30,6 +30,17 @@ namespace Expense.API.Models.DTO
         /// Name or details of the associated User.
         /// </summary>
         public string UserName { get; set; }
+
+        /// <summary>
+        /// How many of the expense's line items this user is assigned to. Null when the expense has
+        /// zero LineItem rows.
+        /// </summary>
+        public int? ItemsAssignedCount { get; set; }
+
+        /// <summary>
+        /// The expense's total line item count. Null when the expense has zero LineItem rows.
+        /// </summary>
+        public int? TotalItemsCount { get; set; }
     }
 }
 

--- a/Models/Domain/Expense/ExpenseUser.cs
+++ b/Models/Domain/Expense/ExpenseUser.cs
@@ -1,4 +1,6 @@
-﻿namespace Expense.API.Models.Domain
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Expense.API.Models.Domain
 {
 	public class ExpenseUser
 	{
@@ -38,6 +40,20 @@
         /// User Share Amount
         /// </summary>
         public double? UserAmount { get; set; }
+
+        /// <summary>
+        /// How many of the expense's line items this user is assigned to. Transient - populated by
+        /// GetAssignUsers, not persisted. Null when the expense has zero LineItem rows.
+        /// </summary>
+        [NotMapped]
+        public int? ItemsAssignedCount { get; set; }
+
+        /// <summary>
+        /// The expense's total line item count. Transient - populated by GetAssignUsers, not
+        /// persisted. Null when the expense has zero LineItem rows.
+        /// </summary>
+        [NotMapped]
+        public int? TotalItemsCount { get; set; }
     }
 }
 

--- a/Repositories/Expense/ExpenseRepository.cs
+++ b/Repositories/Expense/ExpenseRepository.cs
@@ -63,6 +63,11 @@ namespace Expense.API.Repositories.Expense
 
         public async Task<ExpenseUser> CreateExpenseUserAsync(ExpenseUser expenseUser)
         {
+            if (await userDocumentsDbContext.LineItems.AnyAsync(li => li.ExpenseId == expenseUser.ExpenseId))
+            {
+                throw new Exception("This expense's sharing is managed by line-item assignment — use the Document Results page instead.");
+            }
+
             // Check if the User Exists -- Just In Case
             var user = await userDocumentsDbContext.Users.FirstOrDefaultAsync(
                 user => user.Id.Equals(expenseUser.UserId));
@@ -118,6 +123,11 @@ namespace Expense.API.Repositories.Expense
 
         public async Task<List<ExpenseUser>> RemoveExpenseUserAsync(Guid expenseId, Guid userId)
         {
+            if (await userDocumentsDbContext.LineItems.AnyAsync(li => li.ExpenseId == expenseId))
+            {
+                throw new Exception("This expense's sharing is managed by line-item assignment — use the Document Results page instead.");
+            }
+
             var expense = await userDocumentsDbContext.Expenses.FirstOrDefaultAsync(
                 expense => expense.Id.Equals(expenseId));
             if (expense == null)
@@ -157,6 +167,11 @@ namespace Expense.API.Repositories.Expense
 
         public async Task<List<ExpenseUser>> UpdateExpenseUserSharesAsync(Guid expenseId, List<UpdateExpenseUserShareDto> shares)
         {
+            if (await userDocumentsDbContext.LineItems.AnyAsync(li => li.ExpenseId == expenseId))
+            {
+                throw new Exception("This expense's sharing is managed by line-item assignment — use the Document Results page instead.");
+            }
+
             var expense = await userDocumentsDbContext.Expenses.FirstOrDefaultAsync(
                 expense => expense.Id.Equals(expenseId));
             if (expense == null)
@@ -212,6 +227,26 @@ namespace Expense.API.Repositories.Expense
                         })
                     .ToListAsync();
 
+                // N-of-M line item assignment counts, left null when the expense has no LineItem rows.
+                var lineItems = await userDocumentsDbContext.LineItems
+                    .Where(li => li.ExpenseId == expenseId)
+                    .Select(li => li.Assignments.Select(a => a.UserId))
+                    .ToListAsync();
+
+                if (lineItems.Count > 0)
+                {
+                    var assignedCounts = lineItems
+                        .SelectMany(assigneeIds => assigneeIds)
+                        .GroupBy(userId => userId)
+                        .ToDictionary(g => g.Key, g => g.Count());
+
+                    foreach (var expUser in expenseUsers)
+                    {
+                        expUser.TotalItemsCount = lineItems.Count;
+                        expUser.ItemsAssignedCount = assignedCounts.GetValueOrDefault(expUser.UserId);
+                    }
+                }
+
                 return expenseUsers;
             }
             catch (Exception e)
@@ -251,7 +286,10 @@ namespace Expense.API.Repositories.Expense
 
         public async Task<DocumentJobResult?> GetDocResult(Guid expenseId, Guid docId)
         {
-            var result =  await userDocumentsDbContext.DocumentJobResults.Where(doc => doc.ExpenseId.Equals(expenseId) && doc.DocumentId.Equals(docId)).FirstOrDefaultAsync();
+            var result = await userDocumentsDbContext.DocumentJobResults
+                .Include(d => d.LineItems).ThenInclude(li => li.Assignments).ThenInclude(a => a.User)
+                .Where(doc => doc.ExpenseId.Equals(expenseId) && doc.DocumentId.Equals(docId))
+                .FirstOrDefaultAsync();
             return result;
         }
 

--- a/Tests/Expense.API.IntegrationTests/ExpenseControllerLineItemTests.cs
+++ b/Tests/Expense.API.IntegrationTests/ExpenseControllerLineItemTests.cs
@@ -1,0 +1,241 @@
+using System.Linq;
+using System.Net;
+using System.Net.Http.Json;
+using Expense.API.IntegrationTests.Infrastructure;
+using Expense.API.Models.DTO;
+using FluentAssertions;
+using Xunit;
+
+namespace Expense.API.IntegrationTests;
+
+/// <summary>
+/// End-to-end (route -> repository -> DB) coverage for the phase B10 line-item assignment endpoints,
+/// the N-of-M fields on getAssignedUsers, and the guard that retires addUser/removeUser/updateShares
+/// once an expense has any LineItem row.
+/// </summary>
+public class ExpenseControllerLineItemTests : IntegrationTestBase
+{
+    public ExpenseControllerLineItemTests(CustomWebAppFactory factory) : base(factory) { }
+
+    private const string GuardMessage =
+        "This expense's sharing is managed by line-item assignment — use the Document Results page instead.";
+
+    [Fact]
+    public async Task PutLineItemAssignee_with_a_non_friend_returns_400_with_the_expected_message()
+    {
+        var owner = await RegisterAndLoginAsync("eclowner");
+        var stranger = await RegisterAndLoginAsync("eclstranger");
+
+        Guid itemId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Dinner", 10m, "Dining", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 10m);
+            var item = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Pasta", 10m, owner.Id);
+            await db.SaveChangesAsync();
+            itemId = item.Id;
+        });
+
+        var res = await owner.Client.PutAsync($"/api/Expense/lineItem/{itemId}/assignees/{stranger.Id}", null);
+
+        res.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await res.Content.ReadAsStringAsync()).Should().Contain("Users must be friends before sharing an expense.");
+    }
+
+    [Fact]
+    public async Task PutLineItemAssignee_with_an_accepted_friend_returns_200_with_updated_assignees()
+    {
+        var owner = await RegisterAndLoginAsync("eclowner2");
+        var friend = await RegisterAndLoginAsync("eclfriend2");
+        await BefriendAsync(owner, friend);
+
+        Guid itemId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Dinner", 10m, "Dining", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 10m);
+            var item = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Pasta", 10m, owner.Id);
+            await db.SaveChangesAsync();
+            itemId = item.Id;
+        });
+
+        var res = await owner.Client.PutAsync($"/api/Expense/lineItem/{itemId}/assignees/{friend.Id}", null);
+        res.StatusCode.Should().Be(HttpStatusCode.OK, await res.Content.ReadAsStringAsync());
+
+        var dto = await res.Content.ReadFromJsonAsync<LineItemDto>();
+        dto!.Assignees.Select(a => a.UserId).Should().BeEquivalentTo(new[] { owner.Id, friend.Id });
+    }
+
+    [Fact]
+    public async Task DeleteLineItemAssignee_last_remaining_assignee_returns_400_with_the_expected_message()
+    {
+        var owner = await RegisterAndLoginAsync("eclowner3");
+
+        Guid itemId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Snack", 10m, "Dining", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 10m);
+            var item = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Chips", 10m, owner.Id);
+            await db.SaveChangesAsync();
+            itemId = item.Id;
+        });
+
+        var res = await owner.Client.DeleteAsync($"/api/Expense/lineItem/{itemId}/assignees/{owner.Id}");
+
+        res.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await res.Content.ReadAsStringAsync()).Should().Contain("Cannot remove the last remaining assignee from a line item.");
+    }
+
+    [Fact]
+    public async Task DeleteLineItemAssignee_with_more_than_one_assignee_returns_200_with_updated_assignees()
+    {
+        var owner = await RegisterAndLoginAsync("eclowner4");
+        var friend = await RegisterAndLoginAsync("eclfriend4");
+        await BefriendAsync(owner, friend);
+
+        Guid itemId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Lunch", 10m, "Dining", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 10m);
+            var item = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Sandwich", 10m, owner.Id, friend.Id);
+            await db.SaveChangesAsync();
+            itemId = item.Id;
+        });
+
+        var res = await owner.Client.DeleteAsync($"/api/Expense/lineItem/{itemId}/assignees/{friend.Id}");
+        res.StatusCode.Should().Be(HttpStatusCode.OK, await res.Content.ReadAsStringAsync());
+
+        var dto = await res.Content.ReadFromJsonAsync<LineItemDto>();
+        dto!.Assignees.Select(a => a.UserId).Should().BeEquivalentTo(new[] { owner.Id });
+    }
+
+    [Fact]
+    public async Task PutAssignAllLineItems_is_additive_and_rejects_non_friends()
+    {
+        var owner = await RegisterAndLoginAsync("eclowner5");
+        var friendA = await RegisterAndLoginAsync("eclfrienda5");
+        var friendB = await RegisterAndLoginAsync("eclfriendb5");
+        var stranger = await RegisterAndLoginAsync("eclstranger5");
+        await BefriendAsync(owner, friendA);
+        await BefriendAsync(owner, friendB);
+
+        Guid expenseId = Guid.Empty, item1Id = Guid.Empty, item2Id = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Groceries", 40m, "Groceries", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 40m);
+            var item1 = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Milk", 20m, owner.Id, friendA.Id);
+            var item2 = SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Bread", 20m, owner.Id);
+            await db.SaveChangesAsync();
+            expenseId = expense.Id;
+            item1Id = item1.Id;
+            item2Id = item2.Id;
+        });
+
+        var nonFriendRes = await owner.Client.PutAsync($"/api/Expense/{expenseId}/lineItems/assignAll/{stranger.Id}", null);
+        nonFriendRes.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await nonFriendRes.Content.ReadAsStringAsync()).Should().Contain("Users must be friends before sharing an expense.");
+
+        var res = await owner.Client.PutAsync($"/api/Expense/{expenseId}/lineItems/assignAll/{friendB.Id}", null);
+        res.StatusCode.Should().Be(HttpStatusCode.OK, await res.Content.ReadAsStringAsync());
+
+        var items = await res.Content.ReadFromJsonAsync<List<LineItemDto>>();
+        items!.Single(i => i.Id == item1Id).Assignees.Select(a => a.UserId)
+            .Should().BeEquivalentTo(new[] { owner.Id, friendA.Id, friendB.Id });
+        items.Single(i => i.Id == item2Id).Assignees.Select(a => a.UserId)
+            .Should().BeEquivalentTo(new[] { owner.Id, friendB.Id });
+    }
+
+    [Fact]
+    public async Task GetAssignedUsers_reports_N_of_M_line_item_counts_when_the_expense_has_line_items()
+    {
+        var owner = await RegisterAndLoginAsync("eclowner6");
+        var friend = await RegisterAndLoginAsync("eclfriend6");
+        await BefriendAsync(owner, friend);
+
+        Guid expenseId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Groceries", 40m, "Groceries", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 40m);
+            SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Milk", 20m, owner.Id, friend.Id);
+            SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Bread", 20m, owner.Id);
+            SeedData.AddShare(db, expense.Id, owner.Id, 30, 0.75);
+            SeedData.AddShare(db, expense.Id, friend.Id, 10, 0.25);
+            await db.SaveChangesAsync();
+            expenseId = expense.Id;
+        });
+
+        var res = await owner.Client.GetAsync($"/api/Expense/{expenseId}/getAssignedUsers");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var users = await res.Content.ReadFromJsonAsync<List<ExpenseUserDto>>();
+        users!.Should().HaveCount(2);
+        users.First(u => u.UserId == owner.Id).ItemsAssignedCount.Should().Be(2);
+        users.First(u => u.UserId == owner.Id).TotalItemsCount.Should().Be(2);
+        users.First(u => u.UserId == friend.Id).ItemsAssignedCount.Should().Be(1);
+        users.First(u => u.UserId == friend.Id).TotalItemsCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetAssignedUsers_leaves_the_N_of_M_fields_null_when_the_expense_has_no_line_items()
+    {
+        var owner = await RegisterAndLoginAsync("eclowner7");
+        var friend = await RegisterAndLoginAsync("eclfriend7");
+        await BefriendAsync(owner, friend);
+
+        var created = await owner.Client.PostAsJsonAsync("/api/Expense", new AddExpenseDto { Title = "Dinner", Description = "Shared dinner" });
+        created.StatusCode.Should().Be(HttpStatusCode.OK, await created.Content.ReadAsStringAsync());
+        var expense = await created.Content.ReadFromJsonAsync<ExpenseDto>();
+
+        var add = await owner.Client.PostAsync($"/api/Expense/{expense!.Id}/addUser?userId={friend.Id}", null);
+        add.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var res = await owner.Client.GetAsync($"/api/Expense/{expense.Id}/getAssignedUsers");
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var users = await res.Content.ReadFromJsonAsync<List<ExpenseUserDto>>();
+        users!.Should().OnlyContain(u => u.ItemsAssignedCount == null && u.TotalItemsCount == null);
+    }
+
+    [Fact]
+    public async Task AddUser_removeUser_and_updateShares_are_guarded_once_the_expense_has_a_line_item()
+    {
+        var owner = await RegisterAndLoginAsync("eclowner8");
+        var friend = await RegisterAndLoginAsync("eclfriend8");
+        await BefriendAsync(owner, friend);
+
+        Guid expenseId = Guid.Empty;
+        await WithDbAsync(async db =>
+        {
+            var expense = SeedData.AddExpense(db, owner.Id, "Dinner", 10m, "Dining", DateTime.UtcNow);
+            var receipt = SeedData.AddReceipt(db, owner.Id, expense.Id, DateTime.UtcNow);
+            var jobResult = SeedData.AddDocumentJobResult(db, owner.Id, expense.Id, receipt.Id, 10m);
+            SeedData.AddLineItem(db, expense.Id, jobResult.Id, "Pasta", 10m, owner.Id);
+            SeedData.AddShare(db, expense.Id, owner.Id, 10, 1.0);
+            await db.SaveChangesAsync();
+            expenseId = expense.Id;
+        });
+
+        var addRes = await owner.Client.PostAsync($"/api/Expense/{expenseId}/addUser?userId={friend.Id}", null);
+        addRes.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await addRes.Content.ReadAsStringAsync()).Should().Contain(GuardMessage);
+
+        var removeRes = await owner.Client.DeleteAsync($"/api/Expense/{expenseId}/removeUser/{owner.Id}");
+        removeRes.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await removeRes.Content.ReadAsStringAsync()).Should().Contain(GuardMessage);
+
+        var sharesRes = await owner.Client.PutAsJsonAsync($"/api/Expense/{expenseId}/updateShares",
+            new List<UpdateExpenseUserShareDto> { new UpdateExpenseUserShareDto { UserId = owner.Id, UserShare = 1.0 } });
+        sharesRes.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await sharesRes.Content.ReadAsStringAsync()).Should().Contain(GuardMessage);
+    }
+}

--- a/Tests/Expense.API.IntegrationTests/LineItemAssignmentTests.cs
+++ b/Tests/Expense.API.IntegrationTests/LineItemAssignmentTests.cs
@@ -12,11 +12,11 @@ using Xunit;
 namespace Expense.API.IntegrationTests;
 
 /// <summary>
-/// Exercises the line-item assignment business rules directly against IExpenseRepository (there is no
-/// HTTP surface yet - that's phase B10): friendship-gated assign/remove, additive bulk-assign, and the
-/// ExpenseUser recompute that derives per-person totals from assignments. Also exercises
-/// ExpenseAnalysis.StoreResults' first-scan carry-forward of existing ExpenseUser rows onto new
-/// LineItems.
+/// Exercises the line-item assignment business rules directly against IExpenseRepository (the HTTP
+/// surface added in phase B10 is covered end-to-end in ExpenseControllerLineItemTests): friendship-gated
+/// assign/remove, additive bulk-assign, and the ExpenseUser recompute that derives per-person totals
+/// from assignments. Also exercises ExpenseAnalysis.StoreResults' first-scan carry-forward of existing
+/// ExpenseUser rows onto new LineItems.
 /// </summary>
 public class LineItemAssignmentTests : IntegrationTestBase
 {

--- a/docs/ROUTINES_PLAN.md
+++ b/docs/ROUTINES_PLAN.md
@@ -193,7 +193,7 @@ PUT  /api/Expense/{id}/updateShares            line-item assignment — use the 
 - [x] **B7 — Require friendship before adding a user to an expense split**
 - [x] **B8 — LineItem/LineItemAssignment schema**
 - [x] **B9 — Line-item assignment repository, business rules, StoreResults integration**
-- [ ] **B10 — Controller endpoints + guard old manual-share endpoints**
+- [x] **B10 — Controller endpoints + guard old manual-share endpoints**
 
 ---
 


### PR DESCRIPTION
## What was built

Phase B10 from `docs/ROUTINES_PLAN.md` — the final line-item assignment phase, wiring B9's repository logic up to HTTP and retiring the old manual-share endpoints once an expense has scanned line items. This directly fixes the frontend bug reported against `GET /api/Expense/{expenseId}/doc/{docId}`: `lineItems` was always serializing as `[]` because `GetDocResult` never eager-loaded the relation B9 added.

- **`ExpenseRepository.GetDocResult`** — now `.Include(d => d.LineItems).ThenInclude(li => li.Assignments).ThenInclude(a => a.User)`, so the existing B9 AutoMapper map (`DocumentJobResult` → `DocumentResultDto.LineItems`) has data to project.
- **`Controllers/ExpenseController.cs`** — three new endpoints, same conventions as the existing `addUser`/`removeUser` actions:
  - `PUT api/Expense/lineItem/{lineItemId}/assignees/{userId}` → `AssignUserToLineItemAsync`, maps to `LineItemDto`.
  - `DELETE api/Expense/lineItem/{lineItemId}/assignees/{userId}` → `RemoveUserFromLineItemAsync`.
  - `PUT api/Expense/{expenseId}/lineItems/assignAll/{userId}` → `AssignUserToAllLineItemsAsync`, maps to `List<LineItemDto>`.
- **`GetAssignUsers`** — now computes `ItemsAssignedCount`/`TotalItemsCount` per returned `ExpenseUser` via a single query against `LineItems`/`LineItemAssignments` for the expense; both stay `null` when the expense has zero `LineItem` rows. Added the matching `[NotMapped]` transient properties to the `ExpenseUser` domain class (no schema change — verified `dotnet ef migrations add` produces an empty diff) and plain fields to `ExpenseUserDto` (picked up by the existing `CreateMap<ExpenseUser, ExpenseUserDto>()` via AutoMapper's name convention, no `ForMember` needed).
- **Guard** — `CreateExpenseUserAsync`, `RemoveExpenseUserAsync`, `UpdateExpenseUserSharesAsync` now throw `"This expense's sharing is managed by line-item assignment — use the Document Results page instead."` up front when the target expense has any `LineItem` row, before any other logic.

## Testing

- `dotnet build` (API project and whole solution) — **0 errors**, only pre-existing nullable/analyzer warnings.
- `dotnet test Tests/Expense.API.IntegrationTests` — **could not run locally**: same as the B9 PR, this sandbox's Docker daemon starts but pulling `testcontainers/ryuk:0.6.0` is blocked by the egress proxy policy (`403 Forbidden` from the CDN blob host). GitHub Actions (`.github/workflows/integration-tests.yml`) runs the full suite on this PR regardless and is the gate of record.
- New suite `Tests/Expense.API.IntegrationTests/ExpenseControllerLineItemTests.cs`, end-to-end (route → repository → DB):
  - `PUT`/`DELETE lineItem/{id}/assignees/{userId}` — non-friend 400 with the exact message, accepted friend 200 with updated `Assignees`, removing the last remaining assignee 400 with the exact message, removing one of several 200.
  - `PUT {expenseId}/lineItems/assignAll/{userId}` — additive across items, rejects non-friends.
  - `getAssignedUsers` — correct N-of-M counts when the expense has line items; both fields `null` when it has none (regression check).
  - `addUser`/`removeUser`/`updateShares` all 400 with the exact guard message once the expense has a `LineItem` row.
- `Tests/Expense.API.IntegrationTests/LineItemAssignmentTests.cs` (from B9) is unchanged except a doc-comment fix (it now correctly notes the HTTP surface exists, covered separately by the new suite above).

## Deviations from spec

None functionally. `ItemsAssignedCount`/`TotalItemsCount` are computed with one query against `LineItems` (projecting each item's assignee ids) rather than two separate queries against `LineItems` and `LineItemAssignments` — same data, one round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011DDLzQL1Dn1UeXbj8uM36H)_